### PR TITLE
fix the way we lint functions by looking at imports

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,13 +1,24 @@
 {
   "extends": [
     "eslint:recommended",
-    "plugin:node/recommended",
     "plugin:prettier/recommended"
   ],
+  "plugins": ["markdown"],
   "parserOptions": {
     "ecmaVersion": 2018
   },
-  "ignorePatterns": [
-    "node_modules/"
+  "ignorePatterns": ["node_modules/"],
+  "overrides": [
+    {
+      "files": ["**/*.js"],
+      "extends": "plugin:node/recommended"
+    },
+    {
+      "files": ["**/*.md"],
+      "parserOptions": {
+        "ecmaVersion": 2018,
+        "sourceType": "module"
+      }
+    }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -322,3 +322,26 @@ module in your test like so:
 ```js
 import { myAuditFn } from "my-app/tests/helpers/audit";
 ```
+
+### Only linting certain types of tests
+
+If you have an existing codebase, it can often be more manageable to start
+linting segments of the codebase at a time. For example, maybe you only want
+to lint acceptance tests.
+
+You can use ESLint's `overrides` field in your ESLint `.eslintrc.json` config file to accomplish this:
+
+```json
+{
+  "overrides": [
+    {
+      "files": ["tests/acceptance/**/*.js"],
+      "extends": ["plugin:ember-a11y-testing/recommended"]
+    }
+  ]
+}
+```
+
+You can find more information and examples (such as disabling for a certain
+group of files, instead of enabling) on [ESLint's documentation page about
+configuration](https://eslint.org/docs/user-guide/configuring#disabling-rules-only-for-a-group-of-files).

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ For example, the following code will trigger a linting error:
 ```js
 import { module, test } from "qunit";
 import { visit, click, setupApplicationTest } from "@ember/test-helpers";
-import a11yAudit from "ember-a11y-testing";
+import a11yAudit from "ember-a11y-testing/test-support/audit";
 
 module("visiting the bakery", function (hooks) {
   setupApplicationTest(hooks);

--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ module("my acceptance test", function (hooks) {
   test("user can confirm thing", async function (/*assert*/) {
     await visit("/seize-the-means-of-production");
     await confirm('[data-test-selector="confirm-button"]');
-    // eslint will indicate an error here until away `a11yAudit` is added.
+    // eslint will indicate an error here until `await a11yAudit()` is added.
   });
 });
 ```

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ test("my test", async function (/*assert*/) {
 
 ### Rule: ember-a11y-testing/a11y-audit-no-expression
 
-Ensures that `a11yAudit` is actually called instead of just referenced in a test.
+Ensures that `a11yAudit` is actually called instead of just referenced in a test. This can help prevent false positives when the audit isn't actually ran.
 
 Not Allowed:
 

--- a/README.md
+++ b/README.md
@@ -9,16 +9,17 @@ is called after each call to a helper from [@ember/test-helpers](https://github.
 
 For example, the following code will trigger a linting error:
 
-```javascript
-import { module, test } from 'qunit';
-import { vist, click, setupAcceptanceTest } from '@ember/test-helpers';
-import a11yAudit from 'ember-a11y-testing';
+```js
+import { module, test } from "qunit";
+import { visit, click, setupApplicationTest } from "@ember/test-helpers";
+import a11yAudit from "ember-a11y-testing";
 
-module('visiting the bakery', function(hooks) {
-  test('shows kolaches available', async (assert) {
-    await visit('/bakery');
+module("visiting the bakery", function (hooks) {
+  setupApplicationTest(hooks);
+  test("shows kolaches available", async function (/* assert */) {
+    await visit("/bakery");
     await a11yAudit(); // no lint error here
-    await click('#kolache-button');
+    await click("#kolache-button");
     // oops, forgot to call a11yAudit here. ESLint will raise an error
   });
 });
@@ -96,7 +97,7 @@ Or configure the rules you want to use under the rules section.
 There are a few rules in this plugin to facilitate `eslint --fix`, so we
 recommend you keep all of them on.
 
-### Cofniguring which helpers to assert audit after
+### Configuring which helpers to assert audit after
 
 By default, eslint-plugin-ember-a11y-testing will ensure there is a call to
 `a11yAudit` after this subset of helpers from
@@ -135,7 +136,7 @@ If you want to exclude any of these helpers for any reason, you can configure th
 
 ### Auditing custom helpers
 
-Apps and addons often develop their own helpers for interacting with components. eslint-plugin-ember-a11y-testing can audit those as well by specifying them in the `modules` setting. For example, if you a custom helper exported at `confirm` from the `tests/helpers/confirm` module, and the name of your app (as specified in `name` in package.json at the root of your project) is 'myapp':
+Apps and addons often develop their own helpers for interacting with components. eslint-plugin-ember-a11y-testing can audit those as well by specifying them in the `modules` setting. For example, if you have a custom helper exported at `confirm` from the `tests/helpers/confirm` module, and the name of your app (as specified in `name` in package.json at the root of your project) is 'myapp':
 
 ```json
 {
@@ -154,13 +155,14 @@ Apps and addons often develop their own helpers for interacting with components.
 
 This will result in the following code trigger a linting error (and can also be autofixed if you have `eslint --fix` enabled):
 
-```
-import { confirm } from 'myapp/tests/helpers';
+<!-- global module, setupApplicationTest, test, visit -->
+```js
+import { confirm } from "myapp/tests/helpers";
 
-module('my acceptance test', function(hooks) {
+module("my acceptance test", function (hooks) {
   setupApplicationTest(hooks);
-  test('user can confirm thing', function(assert) => {
-    await visit('/seize-the-means-of-production');
+  test("user can confirm thing", async function (/*assert*/) {
+    await visit("/seize-the-means-of-production");
     await confirm('[data-test-selector="confirm-button"]');
     // eslint will indicate an error here until away `a11yAudit` is added.
   });
@@ -173,8 +175,9 @@ By default, `eslint-plugin-ember-a11y-testing` expects you to define imports
 for `a11yAudit` in your tests as listed on the [ember-a11y-testing
 README](https://github.com/ember-a11y/ember-a11y-testing#acceptance-tests):
 
-```javascript
-import a11yAudit from 'ember-a11y-testing/test-support/audit';
+<!-- eslint-disable no-unused-vars -->
+```js
+import a11yAudit from "ember-a11y-testing/test-support/audit";
 ```
 
 However, sometimes it's handy to combine `a11yAudit` with your own setup
@@ -195,14 +198,14 @@ code, or keep configuration for aXe in one place. In that case, you can tell
 }
 ```
 
-```javascript
+```js
 // your module defined at tests/helpers/audit.js
-import a11yAudit from 'ember-a11y-testing/test-support/audit';
+import a11yAudit from "ember-a11y-testing/test-support/audit";
 
 export default async function audit() {
   const axeOptions = {
     // redacted for brevity
-  }
+  };
   await a11yAudit(axeOptions);
 }
 ```
@@ -210,6 +213,7 @@ export default async function audit() {
 `eslint-plugin-ember-a11y-testing` will then expect you to import from that
 module like so:
 
-```javascript
-import a11yAudit from 'my-app/tests/helpers/audit';
+<!-- eslint-disable no-unused-vars -->
+```js
+import a11yAudit from "my-app/tests/helpers/audit";
 ```

--- a/README.md
+++ b/README.md
@@ -217,7 +217,12 @@ If you want to exclude any of these helpers for any reason, you can configure th
 
 ### Auditing custom helpers
 
-Apps and addons often develop their own helpers for interacting with components. eslint-plugin-ember-a11y-testing can audit those as well by specifying them in the `modules` setting. For example, if you have a custom helper exported at `confirm` from the `tests/helpers/confirm` module, and the name of your app (as specified in `name` in package.json at the root of your project) is 'myapp':
+Apps and addons often develop their own helpers for interacting with
+components. eslint-plugin-ember-a11y-testing can audit those as well by
+specifying them in the `modules` setting. For example, if you have a custom
+helper exported at `confirm` from the `tests/helpers` module, and the
+name of your app (as specified in `name` in package.json at the root of your
+project) is 'myapp':
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -184,17 +184,17 @@ By default, eslint-plugin-ember-a11y-testing will ensure there is a call to
 `a11yAudit` after this subset of helpers from
 [@ember/test-helpers](https://github.com/emberjs/ember-test-helpers/blob/master/API.md):
 
-- `visit`
 - `blur`
 - `click`
 - `doubleClick`
 - `fillIn`
 - `focus`
+- `render`
 - `tap`
 - `triggerEvent`
 - `triggerKeyEvent`
 - `typeIn`
-- `render`
+- `visit`
 
 If you want to exclude any of these helpers for any reason, you can configure the `a11y-audit-after-test-helper` plugin as follows:
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,32 @@
 
 [![CircleCI Build Status](https://circleci.com/gh/a11y-tool-sandbox/eslint-plugin-ember-a11y-testing.svg?style=svg)](https://circleci.com/gh/a11y-tool-sandbox/eslint-plugin-ember-a11y-testing)
 
-ESLint plugin for ember-a11y-testing
+ESLint plugin for ember-a11y-testing. This plugin adds some rules to ensure
+that `a11yAudit` from
+[https://github.com/ember-a11y/ember-a11y-testing](https://github.com/ember-a11y/ember-a11y-testing)
+is called after each call to a helper from [@ember/test-helpers](https://github.com/emberjs/ember-test-helpers/blob/master/API.md).
+
+For example, the following code will trigger a linting error:
+
+```javascript
+import { module, test } from 'qunit';
+import { vist, click, setupAcceptanceTest } from '@ember/test-helpers';
+import a11yAudit from 'ember-a11y-testing';
+
+module('visiting the bakery', function(hooks) {
+  test('shows kolaches available', async (assert) {
+    await visit('/bakery');
+    await a11yAudit(); // no lint error here
+    await click('#kolache-button');
+    // oops, forgot to call a11yAudit here. ESLint will raise an error
+  });
+});
+```
+
+This ESLint plugin provides both reporting and autofixing (through `eslint
+--fix` or editor integration) and can serve as a tool to help you migrate to
+auditing your tests with [aXe](https://github.com/dequelabs/axe-core) through
+`ember-a11y-testing`.
 
 ## Installation
 
@@ -60,9 +85,86 @@ Or configure the rules you want to use under the rules section.
 ```json
 {
   "rules": {
-    "ember-a11y-testing/a11y-audit": "error"
+    "ember-a11y-testing/a11y-audit": "error",
+    "ember-a11y-testing/a11y-audit-after-test-helper": "error",
+    "ember-a11y-testing/a11y-audit-no-expression": "error",
+    "ember-a11y-testing/a11y-audit-no-globals": "error",
   }
 }
+```
+
+There are a few rules in this plugin to facilitate `eslint --fix`, so we
+recommend you keep all of them on.
+
+### Cofniguring which helpers to assert audit after
+
+By default, eslint-plugin-ember-a11y-testing will ensure there is a call to
+`a11yAudit` after this subset of helpers from
+[@ember/test-helpers](https://github.com/emberjs/ember-test-helpers/blob/master/API.md):
+
+- `visit`
+- `blur`
+- `click`
+- `doubleClick`
+- `fillIn`
+- `focus`
+- `tap`
+- `triggerEvent`
+- `triggerKeyEvent`
+- `typeIn`
+- `render`
+
+If you want to exclude any of these helpers for any reason, you can configure the `a11y-audit-after-test-helper` plugin as follows:
+
+```json
+{
+  "plugins": ["ember-a11y-testing"],
+  "settings": {
+    "ember-a11y-testing": {
+      "modules": {
+        "@ember/test-helpers": {
+          "exclude": [
+            "fillIn"
+          ]
+        }
+      }
+    }
+  }
+}
+```
+
+### Auditing custom helpers
+
+Apps and addons often develop their own helpers for interacting with components. eslint-plugin-ember-a11y-testing can audit those as well by specifying them in the `modules` setting. For example, if you a custom helper exported at `confirm` from the `tests/helpers/confirm` module, and the name of your app (as specified in `name` in package.json at the root of your project) is 'myapp':
+
+```json
+{
+  "plugins": ["ember-a11y-testing"],
+  "settings": {
+    "ember-a11y-testing": {
+      "modules": {
+        "myapp/tests/helpers": {
+          "include": ["confirm"]
+        }
+      }
+    }
+  }
+}
+```
+
+This will result in the following code trigger a linting error (and can also be autofixed if you have `eslint --fix` enabled):
+
+```
+import { confirm } from 'myapp/tests/helpers';
+
+module('my acceptance test', function(hooks) {
+  setupApplicationTest(hooks);
+  test('user can confirm thing', function(assert) => {
+    await visit('/seize-the-means-of-production');
+    await confirm('[data-test-selector="confirm-button"]');
+    // eslint will indicate an error here until away `a11yAudit` is added.
+  });
+});
 ```
 
 ### Using a custom audit module

--- a/lib/rules/a11y-audit-after-test-helper.js
+++ b/lib/rules/a11y-audit-after-test-helper.js
@@ -28,19 +28,7 @@ module.exports = {
     url:
       "https://github.com/jgwhite/eslint-plugin-ember-a11y-testing/blob/master/lib/rules/a11y-audit-after-test-helper.js",
 
-    schema: [
-      {
-        type: "object",
-        properties: {
-          modules: {
-            type: "object",
-            additionalProperties: {
-              type: "object",
-            },
-          },
-        },
-      },
-    ],
+    schema: [],
 
     parserOptions: {
       ecmaVersion: 2017,

--- a/lib/rules/a11y-audit-after-test-helper.js
+++ b/lib/rules/a11y-audit-after-test-helper.js
@@ -77,11 +77,13 @@ module.exports = {
           );
           const importSpecifiers = importDeclarations.reduce(
             (memo, { specifiers }) => {
-              const matching = specifiers.filter(
-                ({ type, imported }) =>
-                  type === "ImportSpecifier" &&
-                  toInclude.includes(imported.name)
-              );
+              const matching = specifiers.filter(({ type, imported }) => {
+                if (type === "ImportDefaultSpecifier") {
+                  return toInclude.includes("default");
+                } else if (type === "ImportSpecifier") {
+                  return toInclude.includes(imported.name);
+                }
+              });
               return memo.concat(matching);
             },
             []

--- a/lib/rules/a11y-audit-after-test-helper.js
+++ b/lib/rules/a11y-audit-after-test-helper.js
@@ -53,9 +53,6 @@ module.exports = {
   },
 
   create(context) {
-    if (!context.getFilename().includes("tests/acceptance")) {
-      return {};
-    }
     const settings = utils.extractSettings(context);
     const modules = utils.extractModules(settings);
 

--- a/lib/rules/a11y-audit-after-test-helper.js
+++ b/lib/rules/a11y-audit-after-test-helper.js
@@ -32,16 +32,10 @@ module.exports = {
       {
         type: "object",
         properties: {
-          include: {
-            type: "array",
-            items: {
-              type: "string",
-            },
-          },
-          exclude: {
-            type: "array",
-            items: {
-              type: "string",
+          modules: {
+            type: "object",
+            additionalProperties: {
+              type: "object",
             },
           },
         },
@@ -54,8 +48,6 @@ module.exports = {
     },
 
     messages: {
-      a11yAuditMustBeCalled:
-        "a11yAudit must be called as a function and can't be used as a value. Replace `a11yAudit` with added parens, e.g. `a11yAudit()`",
       a11yAuditAfterHelper: "Call a11yAudit after acceptance test helper",
     },
   },
@@ -64,137 +56,134 @@ module.exports = {
     if (!context.getFilename().includes("tests/acceptance")) {
       return {};
     }
-
-    const defaultTestHelperFunctions = [
-      // route helpers
-      "visit",
-
-      // dom interaction helpers
-      "blur",
-      "click",
-      "doubleClick",
-      "fillIn",
-      "focus",
-      "tap",
-      "triggerEvent",
-      "triggerKeyEvent",
-      "typeIn",
-
-      // rendering helpers
-      "render",
-
-      // TODO: decide if wait helpers would be handy to audit
-      // "waitFor",
-      // "waitUntil",
-      // "settled"
-    ];
-
     const settings = utils.extractSettings(context);
-
-    const extractOptions = (rawConfig) => {
-      if (!Array.isArray(rawConfig)) {
-        return extractOptions([]);
-      }
-      const config = rawConfig[0] || {};
-      return {
-        include: [],
-        exclude: [],
-        ...config,
-      };
-    };
-    const options = extractOptions(context.options);
-    const includeFunctionNames = options.include;
-
-    const excludeFunctionNames = options.exclude;
+    const modules = utils.extractModules(settings);
 
     const declaration = utils.findA11yAuditImportDeclaration(context, settings);
     const a11yAuditIdentifier = declaration
       ? declaration.local.name
       : utils.DEFAULT_A11Y_AUDIT_VARIABLE;
 
-    const functionSelectors = []
-      .concat(defaultTestHelperFunctions, includeFunctionNames)
-      .filter((fn) => !excludeFunctionNames.includes(fn))
-      .map((helperName) => `[callee.name="${helperName}"]`)
-      .join(",");
+    Object.entries(modules).forEach(([sourceName, config]) => {
+      const { include, exclude } = config;
+      const totalImportNames = include.filter(
+        (importName) => !exclude.includes(importName)
+      );
+      forEachImportVariable(sourceName, totalImportNames, (variable) => {
+        variable.references.forEach((ref) => {
+          const node = ref.identifier;
+          if (node.parent.type === "CallExpression") {
+            visit(node.parent);
+          }
+        });
+      });
+    });
+    function forEachImportVariable(sourceName, toInclude, callback) {
+      const sourceCode = context.getSourceCode();
+      const importDeclarations = sourceCode.ast.body.filter(
+        ({ type, source }) => {
+          return (
+            type === "ImportDeclaration" &&
+            source &&
+            source.value === sourceName
+          );
+        }
+      );
+      const importSpecifiers = importDeclarations.reduce(
+        (memo, { specifiers }) => {
+          const matching = specifiers.filter(
+            ({ type, imported }) =>
+              type === "ImportSpecifier" && toInclude.includes(imported.name)
+          );
+          return memo.concat(matching);
+        },
+        []
+      );
+      importSpecifiers.forEach((specifier) => {
+        context.getDeclaredVariables(specifier).forEach((variable) => {
+          callback(variable);
+        });
+      });
+    }
 
-    return {
-      ["CallExpression" + functionSelectors]: function (node) {
-        const parentExpressionStatementNode = utils.findParentOfType(
+    function visit(node) {
+      const parentExpressionStatementNode = utils.findParentOfType(
+        node,
+        "ExpressionStatement"
+      );
+
+      const nextToken = context
+        .getSourceCode()
+        .getTokenAfter(parentExpressionStatementNode);
+
+      const nextNode = nextToken
+        ? context.getNodeByRangeIndex(...nextToken.range)
+        : null;
+
+      const nextNodeExists = Boolean(nextNode);
+
+      const isA11yAudit = (node) => {
+        if (!node) {
+          return false;
+        }
+        if (node.parent && node.parent.type === "CallExpression") {
+          return (
+            node.parent.callee.type === "Identifier" &&
+            node.parent.callee.name === a11yAuditIdentifier
+          );
+        } else if (
+          node.type === "AwaitExpression" &&
+          node.argument.type === "CallExpression"
+        ) {
+          return (
+            node.argument.callee.type === "Identifier" &&
+            node.argument.callee.name === a11yAuditIdentifier
+          );
+        }
+      };
+      const nextNodeIsA11yAudit = nextNodeExists && isA11yAudit(nextNode);
+
+      if (!nextNodeExists || !nextNodeIsA11yAudit) {
+        context.report({
           node,
-          "ExpressionStatement"
-        );
-
-        const nextToken = context
-          .getSourceCode()
-          .getTokenAfter(parentExpressionStatementNode);
-
-        const nextNode = nextToken
-          ? context.getNodeByRangeIndex(...nextToken.range)
-          : null;
-
-        const nextNodeExists = Boolean(nextNode);
-
-        const isA11yAudit = (node) => {
-          if (!node) {
-            return false;
-          }
-          if (node.parent && node.parent.type === "CallExpression") {
-            return (
-              node.parent.callee.type === "Identifier" &&
-              node.parent.callee.name === a11yAuditIdentifier
-            );
-          } else if (
-            node.type === "AwaitExpression" &&
-            node.argument.type === "CallExpression"
-          ) {
-            return (
-              node.argument.callee.type === "Identifier" &&
-              node.argument.callee.name === a11yAuditIdentifier
-            );
-          }
-        };
-        const nextNodeIsA11yAudit = nextNodeExists && isA11yAudit(nextNode);
-
-        if (!nextNodeExists || !nextNodeIsA11yAudit) {
-          context.report({
-            node,
-            messageId: "a11yAuditAfterHelper",
-            fix(fixer) {
-              // don't attempt to autofix when helper is passed to a function, e.g.
-              // assert.throws(fillIn('#foo', 'hi))
-              if (node.parent.type === "CallExpression") {
+          messageId: "a11yAuditAfterHelper",
+          fix(fixer) {
+            // don't attempt to autofix when helper is passed to a function, e.g.
+            // assert.throws(fillIn('#foo', 'hi))
+            if (node.parent.type === "CallExpression") {
+              return;
+            }
+            if (nextNode) {
+              // don't autofix `a11yAudit` (e.g. without parens/not a call expression)
+              // it should get autofixed by a11y-audit-no-expression instead.
+              if (
+                nextNode.type === "ExpressionStatement" &&
+                nextNode.expression.type === "Identifier" &&
+                nextNode.expression.name === a11yAuditIdentifier
+              ) {
                 return;
-              }
-              if (nextNode) {
-                // don't autofix `a11yAudit` (e.g. without parens/not a call expression)
-                // it should get autofixed by a11y-audit-no-expression instead.
+              } else if (nextNode.type === "AwaitExpression") {
                 if (
-                  nextNode.type === "ExpressionStatement" &&
-                  nextNode.expression.type === "Identifier" &&
-                  nextNode.expression.name === a11yAuditIdentifier
+                  nextNode.argument.type === "Identifier" &&
+                  nextNode.argument.name === a11yAuditIdentifier
                 ) {
                   return;
-                } else if (nextNode.type === "AwaitExpression") {
-                  if (
-                    nextNode.argument.type === "Identifier" &&
-                    nextNode.argument.name === a11yAuditIdentifier
-                  ) {
-                    return;
-                  }
                 }
               }
-              let fixerNode = node;
-              let parentFn = utils.findParentOfType(node, /Function/);
-              let prefix = parentFn && parentFn.async ? "await " : "";
-              return fixer.insertTextAfter(
-                fixerNode,
-                `; ${prefix}${a11yAuditIdentifier}()`
-              );
-            },
-          });
-        }
-      },
+            }
+            let fixerNode = node;
+            let parentFn = utils.findParentOfType(node, /FunctionDeclaration/);
+            let prefix = parentFn && parentFn.async ? "await " : "";
+            return fixer.insertTextAfter(
+              fixerNode,
+              `; ${prefix}${a11yAuditIdentifier}()`
+            );
+          },
+        });
+      }
+    }
+    return {
+      "Program:exit"(/*node*/) {},
     };
   },
 };

--- a/lib/rules/a11y-audit-after-test-helper.js
+++ b/lib/rules/a11y-audit-after-test-helper.js
@@ -158,14 +158,13 @@ module.exports = {
                     }
                   }
                 }
-                let fixerNode = node;
                 let parentFn = utils.findParentOfType(
                   node,
                   /FunctionDeclaration/
                 );
                 let prefix = parentFn && parentFn.async ? "await " : "";
                 return fixer.insertTextAfter(
-                  fixerNode,
+                  node,
                   `; ${prefix}${a11yAuditIdentifier}()`
                 );
               },

--- a/lib/rules/a11y-audit-after-test-helper.js
+++ b/lib/rules/a11y-audit-after-test-helper.js
@@ -36,134 +36,143 @@ module.exports = {
   },
 
   create(context) {
-    const settings = utils.extractSettings(context);
-    const modules = utils.extractModules(settings);
+    return {
+      ["Program:exit"](/* node */) {
+        const settings = utils.extractSettings(context);
+        const modules = utils.extractModules(settings);
 
-    const declaration = utils.findA11yAuditImportDeclaration(context, settings);
-    const a11yAuditIdentifier = declaration
-      ? declaration.local.name
-      : utils.DEFAULT_A11Y_AUDIT_VARIABLE;
+        const declaration = utils.findA11yAuditImportDeclaration(
+          context,
+          settings
+        );
+        const a11yAuditIdentifier = declaration
+          ? declaration.local.name
+          : utils.DEFAULT_A11Y_AUDIT_VARIABLE;
 
-    Object.entries(modules).forEach(([sourceName, config]) => {
-      const { include, exclude } = config;
-      const totalImportNames = include.filter(
-        (importName) => !exclude.includes(importName)
-      );
-      forEachImportVariable(sourceName, totalImportNames, (variable) => {
-        variable.references.forEach((ref) => {
-          const node = ref.identifier;
-          if (node.parent.type === "CallExpression") {
-            visit(node.parent);
-          }
+        Object.entries(modules).forEach(([sourceName, config]) => {
+          const { include, exclude } = config;
+          const totalImportNames = include.filter(
+            (importName) => !exclude.includes(importName)
+          );
+          forEachImportVariable(sourceName, totalImportNames, (variable) => {
+            variable.references.forEach((ref) => {
+              const node = ref.identifier;
+              if (node.parent.type === "CallExpression") {
+                visit(node.parent);
+              }
+            });
+          });
         });
-      });
-    });
-    function forEachImportVariable(sourceName, toInclude, callback) {
-      const sourceCode = context.getSourceCode();
-      const importDeclarations = sourceCode.ast.body.filter(
-        ({ type, source }) => {
-          return (
-            type === "ImportDeclaration" &&
-            source &&
-            source.value === sourceName
-          );
-        }
-      );
-      const importSpecifiers = importDeclarations.reduce(
-        (memo, { specifiers }) => {
-          const matching = specifiers.filter(
-            ({ type, imported }) =>
-              type === "ImportSpecifier" && toInclude.includes(imported.name)
-          );
-          return memo.concat(matching);
-        },
-        []
-      );
-      importSpecifiers.forEach((specifier) => {
-        context.getDeclaredVariables(specifier).forEach((variable) => {
-          callback(variable);
-        });
-      });
-    }
 
-    function visit(node) {
-      const parentExpressionStatementNode = utils.findParentOfType(
-        node,
-        "ExpressionStatement"
-      );
-
-      const nextToken = context
-        .getSourceCode()
-        .getTokenAfter(parentExpressionStatementNode);
-
-      const nextNode = nextToken
-        ? context.getNodeByRangeIndex(...nextToken.range)
-        : null;
-
-      const nextNodeExists = Boolean(nextNode);
-
-      const isA11yAudit = (node) => {
-        if (!node) {
-          return false;
-        }
-        if (node.parent && node.parent.type === "CallExpression") {
-          return (
-            node.parent.callee.type === "Identifier" &&
-            node.parent.callee.name === a11yAuditIdentifier
-          );
-        } else if (
-          node.type === "AwaitExpression" &&
-          node.argument.type === "CallExpression"
-        ) {
-          return (
-            node.argument.callee.type === "Identifier" &&
-            node.argument.callee.name === a11yAuditIdentifier
-          );
-        }
-      };
-      const nextNodeIsA11yAudit = nextNodeExists && isA11yAudit(nextNode);
-
-      if (!nextNodeExists || !nextNodeIsA11yAudit) {
-        context.report({
-          node,
-          messageId: "a11yAuditAfterHelper",
-          fix(fixer) {
-            // don't attempt to autofix when helper is passed to a function, e.g.
-            // assert.throws(fillIn('#foo', 'hi))
-            if (node.parent.type === "CallExpression") {
-              return;
+        function forEachImportVariable(sourceName, toInclude, callback) {
+          const sourceCode = context.getSourceCode();
+          const importDeclarations = sourceCode.ast.body.filter(
+            ({ type, source }) => {
+              return (
+                type === "ImportDeclaration" &&
+                source &&
+                source.value === sourceName
+              );
             }
-            if (nextNode) {
-              // don't autofix `a11yAudit` (e.g. without parens/not a call expression)
-              // it should get autofixed by a11y-audit-no-expression instead.
-              if (
-                nextNode.type === "ExpressionStatement" &&
-                nextNode.expression.type === "Identifier" &&
-                nextNode.expression.name === a11yAuditIdentifier
-              ) {
-                return;
-              } else if (nextNode.type === "AwaitExpression") {
-                if (
-                  nextNode.argument.type === "Identifier" &&
-                  nextNode.argument.name === a11yAuditIdentifier
-                ) {
+          );
+          const importSpecifiers = importDeclarations.reduce(
+            (memo, { specifiers }) => {
+              const matching = specifiers.filter(
+                ({ type, imported }) =>
+                  type === "ImportSpecifier" &&
+                  toInclude.includes(imported.name)
+              );
+              return memo.concat(matching);
+            },
+            []
+          );
+          importSpecifiers.forEach((specifier) => {
+            context.getDeclaredVariables(specifier).forEach((variable) => {
+              callback(variable);
+            });
+          });
+        }
+
+        function visit(node) {
+          const parentExpressionStatementNode = utils.findParentOfType(
+            node,
+            "ExpressionStatement"
+          );
+
+          const nextToken = context
+            .getSourceCode()
+            .getTokenAfter(parentExpressionStatementNode);
+
+          const nextNode = nextToken
+            ? context.getNodeByRangeIndex(...nextToken.range)
+            : null;
+
+          const nextNodeExists = Boolean(nextNode);
+
+          const isA11yAudit = (node) => {
+            if (!node) {
+              return false;
+            }
+            if (node.parent && node.parent.type === "CallExpression") {
+              return (
+                node.parent.callee.type === "Identifier" &&
+                node.parent.callee.name === a11yAuditIdentifier
+              );
+            } else if (
+              node.type === "AwaitExpression" &&
+              node.argument.type === "CallExpression"
+            ) {
+              return (
+                node.argument.callee.type === "Identifier" &&
+                node.argument.callee.name === a11yAuditIdentifier
+              );
+            }
+          };
+          const nextNodeIsA11yAudit = nextNodeExists && isA11yAudit(nextNode);
+
+          if (!nextNodeExists || !nextNodeIsA11yAudit) {
+            context.report({
+              node,
+              messageId: "a11yAuditAfterHelper",
+              fix(fixer) {
+                // don't attempt to autofix when helper is passed to a function, e.g.
+                // assert.throws(fillIn('#foo', 'hi))
+                if (node.parent.type === "CallExpression") {
                   return;
                 }
-              }
-            }
-            let fixerNode = node;
-            let parentFn = utils.findParentOfType(node, /FunctionDeclaration/);
-            let prefix = parentFn && parentFn.async ? "await " : "";
-            return fixer.insertTextAfter(
-              fixerNode,
-              `; ${prefix}${a11yAuditIdentifier}()`
-            );
-          },
-        });
-      }
-    }
-    return {
-      "Program:exit"(/*node*/) {},
+                if (nextNode) {
+                  // don't autofix `a11yAudit` (e.g. without parens/not a call expression)
+                  // it should get autofixed by a11y-audit-no-expression instead.
+                  if (
+                    nextNode.type === "ExpressionStatement" &&
+                    nextNode.expression.type === "Identifier" &&
+                    nextNode.expression.name === a11yAuditIdentifier
+                  ) {
+                    return;
+                  } else if (nextNode.type === "AwaitExpression") {
+                    if (
+                      nextNode.argument.type === "Identifier" &&
+                      nextNode.argument.name === a11yAuditIdentifier
+                    ) {
+                      return;
+                    }
+                  }
+                }
+                let fixerNode = node;
+                let parentFn = utils.findParentOfType(
+                  node,
+                  /FunctionDeclaration/
+                );
+                let prefix = parentFn && parentFn.async ? "await " : "";
+                return fixer.insertTextAfter(
+                  fixerNode,
+                  `; ${prefix}${a11yAuditIdentifier}()`
+                );
+              },
+            });
+          }
+        }
+      },
     };
   },
 };

--- a/lib/rules/a11y-audit-after-test-helper.js
+++ b/lib/rules/a11y-audit-after-test-helper.js
@@ -30,11 +30,6 @@ module.exports = {
 
     schema: [],
 
-    parserOptions: {
-      ecmaVersion: 2017,
-      sourceType: "module",
-    },
-
     messages: {
       a11yAuditAfterHelper: "Call a11yAudit after acceptance test helper",
     },

--- a/lib/rules/a11y-audit-no-globals.js
+++ b/lib/rules/a11y-audit-no-globals.js
@@ -41,9 +41,6 @@ module.exports = {
   },
 
   create(context) {
-    if (!context.getFilename().includes("tests/acceptance")) {
-      return {};
-    }
     const settings = utils.extractSettings(context);
 
     const a11yImportDeclaration = utils.findA11yAuditImportDeclaration(

--- a/lib/rules/a11y-audit-no-globals.js
+++ b/lib/rules/a11y-audit-no-globals.js
@@ -28,11 +28,6 @@ module.exports = {
 
     schema: [],
 
-    parserOptions: {
-      ecmaVersion: 2018,
-      sourceType: "module",
-    },
-
     messages: {
       a11yAuditNoGlobals: "'{{name}} must be imported from {{package}}",
       a11yAuditNoGlobalsUseImportName:

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -61,3 +61,55 @@ exports.extractSettings = function extractSettings({ settings }) {
 
   return { ...defaults, ...providedSettings };
 };
+
+const defaultTestHelperFunctions = [
+  // route helpers
+  "visit",
+
+  // dom interaction helpers
+  "blur",
+  "click",
+  "doubleClick",
+  "fillIn",
+  "focus",
+  "tap",
+  "triggerEvent",
+  "triggerKeyEvent",
+  "typeIn",
+
+  // rendering helpers
+  "render",
+
+  // TODO: decide if wait helpers would be handy to audit
+  // "waitFor",
+  // "waitUntil",
+  // "settled"
+];
+
+exports.extractModules = function extractModules(settings) {
+  const modz = settings.modules || {};
+  const emberTestHelpersDefaults = {
+    include: defaultTestHelperFunctions,
+    exclude: [],
+  };
+  let emberTestHelpersConfig = modz["@ember/test-helpers"] || {};
+  emberTestHelpersConfig = {
+    ...emberTestHelpersDefaults,
+    ...emberTestHelpersConfig,
+  };
+  const modzWithDefaults = {
+    "@ember/test-helpers": emberTestHelpersConfig,
+    ...modz,
+  };
+  return Object.entries(modzWithDefaults).reduce(
+    (memo, [sourceName, config]) => {
+      memo[sourceName] = {
+        include: [],
+        exclude: [],
+        ...config,
+      };
+      return memo;
+    },
+    {}
+  );
+};

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "author": "Jamie White",
   "main": "lib/index.js",
   "scripts": {
-    "lint:fix": "eslint --ext js,js --fix .",
+    "lint:fix": "eslint --ext js,md --fix .",
     "test": "eslint --ext js,md . && mocha tests --recursive"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "author": "Jamie White",
   "main": "lib/index.js",
   "scripts": {
-    "test": "eslint . && mocha tests --recursive"
+    "lint:fix": "eslint --ext js,js --fix .",
+    "test": "eslint --ext js,md . && mocha tests --recursive"
   },
   "dependencies": {
     "requireindex": "~1.1.0"
@@ -18,6 +19,7 @@
   "devDependencies": {
     "eslint": "^6.8.0",
     "eslint-config-prettier": "^6.11.0",
+    "eslint-plugin-markdown": "^1.0.2",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^3.1.3",
     "eslint-plugin-yaml": "^0.1.3",

--- a/tests/lib/rules/a11y-audit-after-test-helper.js
+++ b/tests/lib/rules/a11y-audit-after-test-helper.js
@@ -19,152 +19,202 @@ const { RuleTester } = require("eslint/lib/rule-tester");
 const TEST_FILE_NAME = "tests/acceptance/application-test.js";
 const ruleTester = new RuleTester();
 
-ruleTester.run("a11y-audit-after-test-helper", rule, {
+function runWithModernSyntax(testName, rule, options) {
+  const makeTestModern = (testCase) => {
+    const defaultParserOptions = {
+      parserOptions: {
+        ecmaVersion: 2018,
+        sourceType: "module",
+      },
+    };
+    return {
+      ...defaultParserOptions,
+      ...testCase,
+    };
+  };
+  const validCases = (options.valid || []).map(makeTestModern);
+  const invalidCases = (options.invalid || []).map(makeTestModern);
+  return ruleTester.run(testName, rule, {
+    ...options,
+    valid: validCases,
+    invalid: invalidCases,
+  });
+}
+
+runWithModernSyntax("a11y-audit-after-test-helper", rule, {
   valid: [
     // visit
     {
-      code: `visit(); a11yAudit();`,
+      code: `
+      import { visit } from '@ember/test-helpers';
+      visit();
+      a11yAudit();`,
       filename: TEST_FILE_NAME,
     },
     {
-      code: `visit();
+      code: `
+      import { visit } from '@ember/test-helpers';
+      visit();
       a11yAudit();`,
       filename: TEST_FILE_NAME,
     },
 
     // rule not applicable outside of tests/acceptance folder
     {
-      code: `visit();`,
+      code: `import { visit } from '@ember/test-helpers'; visit();`,
       filename: "app/controllers/application.js",
     },
 
     // rule not applicable in non-acceptance tests
     {
-      code: `visit();`,
+      code: `import { visit } from '@ember/test-helpers'; visit();`,
       filename: "tests/integration/my-test.js",
     },
 
     // rule not applicable if function is excluded
     {
-      code: `visit();`,
+      code: `import { visit } from '@ember/test-helpers'; visit();`,
       filename: TEST_FILE_NAME,
-      options: [
-        {
-          exclude: ["visit"],
+      settings: {
+        "ember-a11y-testing": {
+          modules: {
+            "@ember/test-helpers": {
+              exclude: ["visit"],
+            },
+          },
         },
-      ],
+      },
     },
 
     //
     // smoke tests on other default test helpers
     //
     {
-      code: `blur(); a11yAudit();`,
+      code: `import { blur } from '@ember/test-helpers'; blur(); a11yAudit();`,
       filename: TEST_FILE_NAME,
     },
     {
-      code: `click(); a11yAudit();`,
+      code: `import { click } from '@ember/test-helpers'; click(); a11yAudit();`,
       filename: TEST_FILE_NAME,
     },
     {
-      code: `doubleClick(); a11yAudit();`,
+      code: `import { doubleClick } from '@ember/test-helpers'; doubleClick(); a11yAudit();`,
       filename: TEST_FILE_NAME,
     },
     {
-      code: `focus(); a11yAudit();`,
+      code: `import { focus } from '@ember/test-helpers'; focus(); a11yAudit();`,
       filename: TEST_FILE_NAME,
     },
     {
-      code: `tap(); a11yAudit();`,
+      code: `import { tap } from '@ember/test-helpers'; tap(); a11yAudit();`,
       filename: TEST_FILE_NAME,
     },
     {
-      code: `triggerEvent(); a11yAudit();`,
+      code: `import { triggerEvent } from '@ember/test-helpers'; triggerEvent(); a11yAudit();`,
       filename: TEST_FILE_NAME,
     },
     {
-      code: `triggerKeyEvent(); a11yAudit();`,
+      code: `import { triggerKeyEvent } from '@ember/test-helpers'; triggerKeyEvent(); a11yAudit();`,
       filename: TEST_FILE_NAME,
     },
     {
-      code: `async function foo() { await triggerKeyEvent(); await a11yAudit(); }`,
+      code: `import { triggerKeyEvent } from '@ember/test-helpers'; async function foo() { await triggerKeyEvent(); await a11yAudit(); }`,
       filename: TEST_FILE_NAME,
-      parserOptions: {
-        ecmaVersion: "2018",
-      },
     },
     // for of inside await
     {
-      code: `async function doStuff() {
+      code: `
+      import { click, blur } from '@ember/test-helpers';
+      async function doStuff() {
         for (const x of y) {
           await click(); a11yAudit();
           await blur(); a11yAudit();
         }
       }`,
       filename: TEST_FILE_NAME,
-      parserOptions: {
-        ecmaVersion: "2019",
-      },
     },
   ],
   invalid: [
     // nested block statements
     {
-      code: `async function doStuff() {
-        for await (const x of y) {
-          await fillIn(); await a11yAudit();
-          await blur('[data-test-selector]');
-        }
-      }`,
+      code: `import { blur, fillIn } from "@ember/test-helpers";
+        async function doStuff() {
+          for await (const x of y) {
+            await fillIn(); await a11yAudit();
+            await blur('[data-test-selector]');
+          }
+        }`,
       errors: [{ messageId: "a11yAuditAfterHelper" }],
       filename: TEST_FILE_NAME,
-      output: `async function doStuff() {
-        for await (const x of y) {
-          await fillIn(); await a11yAudit();
-          await blur('[data-test-selector]'); await a11yAudit();
-        }
-      }`,
-      parserOptions: {
-        ecmaVersion: 2018,
-        sourceType: "module",
-      },
+      output: `import { blur, fillIn } from "@ember/test-helpers";
+        async function doStuff() {
+          for await (const x of y) {
+            await fillIn(); await a11yAudit();
+            await blur('[data-test-selector]'); await a11yAudit();
+          }
+        }`,
+    },
+    // renaming ember test helper using import { helper as otherVariable }
+    {
+      code: `import { blur as blur2 /* woo hoo */, fillIn } from "@ember/test-helpers";
+        async function doStuff() {
+          for await (const x of y) {
+            await fillIn(); await a11yAudit();
+            await blur2('[data-test-selector]');
+          }
+        }`,
+      errors: [{ messageId: "a11yAuditAfterHelper" }],
+      filename: TEST_FILE_NAME,
+      output: `import { blur as blur2 /* woo hoo */, fillIn } from "@ember/test-helpers";
+        async function doStuff() {
+          for await (const x of y) {
+            await fillIn(); await a11yAudit();
+            await blur2('[data-test-selector]'); await a11yAudit();
+          }
+        }`,
     },
     // doesn't try to autofix if passed to function
     {
-      code: `assert.throws(fillIn('foo', 'bar'));`,
+      code: `import { fillIn } from "@ember/test-helpers"; assert.throws(fillIn('foo', 'bar'));`,
       errors: [{ messageId: "a11yAuditAfterHelper" }],
       filename: TEST_FILE_NAME,
-      output: `assert.throws(fillIn('foo', 'bar'));`,
-      parserOptions: {
-        ecmaVersion: 2018,
-        sourceType: "module",
-      },
+      output: `import { fillIn } from "@ember/test-helpers"; assert.throws(fillIn('foo', 'bar'));`,
     },
     // without adding a11yAudit after using `include` option
     {
-      code: "myCustom();",
-      options: [
-        {
-          include: ["myCustom"],
+      code: 'import {myCustom} from "custom"; myCustom();',
+      settings: {
+        "ember-a11y-testing": {
+          modules: {
+            custom: {
+              include: ["myCustom"],
+            },
+          },
         },
-      ],
+      },
       errors: [{ messageId: "a11yAuditAfterHelper" }],
       filename: TEST_FILE_NAME,
-      output: `myCustom(); a11yAudit();`,
+      output: `import {myCustom} from "custom"; myCustom(); a11yAudit();`,
     },
     // without adding a11yAudit after using `include` option (multiple)
     {
       code: `
+        import { myCustom, anotherCustom } from 'custom';
         myCustom();
         a11yAudit();
 
         anotherCustom();`,
-      options: [
-        {
-          include: ["myCustom", "anotherCustom"],
+      settings: {
+        "ember-a11y-testing": {
+          modules: {
+            custom: {
+              include: ["myCustom", "anotherCustom"],
+            },
+          },
         },
-      ],
+      },
       output: `
+        import { myCustom, anotherCustom } from 'custom';
         myCustom();
         a11yAudit();
 
@@ -172,55 +222,96 @@ ruleTester.run("a11y-audit-after-test-helper", rule, {
       errors: [{ messageId: "a11yAuditAfterHelper" }],
       filename: TEST_FILE_NAME,
     },
+    // using custom helper with ember test helpers
+    {
+      code: `
+            import { myCustom, anotherCustom } from 'custom';
+            import { click } from '@ember/test-helpers';
+            myCustom();
+            a11yAudit();
+            click();
+
+            anotherCustom();`,
+      settings: {
+        "ember-a11y-testing": {
+          modules: {
+            custom: {
+              include: ["myCustom", "anotherCustom"],
+            },
+          },
+        },
+      },
+      output: `
+            import { myCustom, anotherCustom } from 'custom';
+            import { click } from '@ember/test-helpers';
+            myCustom();
+            a11yAudit();
+            click(); a11yAudit();
+
+            anotherCustom(); a11yAudit();`,
+      errors: [
+        { messageId: "a11yAuditAfterHelper" },
+        { messageId: "a11yAuditAfterHelper" },
+      ],
+      filename: TEST_FILE_NAME,
+    },
 
     //
     // smoke tests on other default test helpers
     //
-
     {
-      code: "blur();",
+      code: 'import { blur } from "@ember/test-helpers"; blur();',
       errors: [{ messageId: "a11yAuditAfterHelper" }],
       filename: TEST_FILE_NAME,
-      output: `blur(); a11yAudit();`,
+      output:
+        'import { blur } from "@ember/test-helpers"; blur(); a11yAudit();',
     },
     {
-      code: "click();",
+      code: 'import { click } from "@ember/test-helpers"; click();',
       errors: [{ messageId: "a11yAuditAfterHelper" }],
       filename: TEST_FILE_NAME,
-      output: `click(); a11yAudit();`,
+      output:
+        'import { click } from "@ember/test-helpers"; click(); a11yAudit();',
     },
     {
-      code: "doubleClick();",
+      code: 'import { doubleClick } from "@ember/test-helpers"; doubleClick();',
       errors: [{ messageId: "a11yAuditAfterHelper" }],
       filename: TEST_FILE_NAME,
-      output: `doubleClick(); a11yAudit();`,
+      output:
+        'import { doubleClick } from "@ember/test-helpers"; doubleClick(); a11yAudit();',
     },
     {
-      code: "focus();",
+      code: 'import { focus } from "@ember/test-helpers"; focus();',
       errors: [{ messageId: "a11yAuditAfterHelper" }],
       filename: TEST_FILE_NAME,
-      output: `focus(); a11yAudit();`,
+      output:
+        'import { focus } from "@ember/test-helpers"; focus(); a11yAudit();',
     },
     {
-      code: "tap();",
+      code: 'import { tap } from "@ember/test-helpers"; tap();',
       errors: [{ messageId: "a11yAuditAfterHelper" }],
       filename: TEST_FILE_NAME,
-      output: `tap(); a11yAudit();`,
+      output: 'import { tap } from "@ember/test-helpers"; tap(); a11yAudit();',
     },
     {
-      code: "triggerEvent();",
+      code:
+        'import { triggerEvent } from "@ember/test-helpers"; triggerEvent();',
       errors: [{ messageId: "a11yAuditAfterHelper" }],
       filename: TEST_FILE_NAME,
-      output: `triggerEvent(); a11yAudit();`,
+      output:
+        'import { triggerEvent } from "@ember/test-helpers"; triggerEvent(); a11yAudit();',
     },
     {
-      code: "triggerKeyEvent();",
+      code:
+        'import { triggerKeyEvent } from "@ember/test-helpers"; triggerKeyEvent();',
       errors: [{ messageId: "a11yAuditAfterHelper" }],
       filename: TEST_FILE_NAME,
-      output: `triggerKeyEvent(); a11yAudit();`,
+      output:
+        'import { triggerKeyEvent } from "@ember/test-helpers"; triggerKeyEvent(); a11yAudit();',
     },
     {
       code: `
+      import { visit } from '@ember/test-helpers';
       import a11yTesting24 from "ember-a11y-testing/test-support/audit";
       async function foo() {
         await visit();
@@ -228,14 +319,11 @@ ruleTester.run("a11y-audit-after-test-helper", rule, {
       errors: [{ messageId: "a11yAuditAfterHelper" }],
       filename: TEST_FILE_NAME,
       output: `
+      import { visit } from '@ember/test-helpers';
       import a11yTesting24 from "ember-a11y-testing/test-support/audit";
       async function foo() {
         await visit(); await a11yTesting24();
       }`,
-      parserOptions: {
-        ecmaVersion: "2018",
-        sourceType: "module",
-      },
     },
   ],
 });

--- a/tests/lib/rules/a11y-audit-after-test-helper.js
+++ b/tests/lib/rules/a11y-audit-after-test-helper.js
@@ -195,13 +195,13 @@ runWithModernSyntax("a11y-audit-after-test-helper", rule, {
     // using custom helper with ember test helpers
     {
       code: `
-            import { myCustom, anotherCustom } from 'custom';
-            import { click } from '@ember/test-helpers';
-            myCustom();
-            a11yAudit();
-            click();
+        import { myCustom, anotherCustom } from 'custom';
+        import { click } from '@ember/test-helpers';
+        myCustom();
+        a11yAudit();
+        click();
 
-            anotherCustom();`,
+        anotherCustom();`,
       settings: {
         "ember-a11y-testing": {
           modules: {
@@ -212,17 +212,36 @@ runWithModernSyntax("a11y-audit-after-test-helper", rule, {
         },
       },
       output: `
-            import { myCustom, anotherCustom } from 'custom';
-            import { click } from '@ember/test-helpers';
-            myCustom();
-            a11yAudit();
-            click(); a11yAudit();
+        import { myCustom, anotherCustom } from 'custom';
+        import { click } from '@ember/test-helpers';
+        myCustom();
+        a11yAudit();
+        click(); a11yAudit();
 
-            anotherCustom(); a11yAudit();`,
+        anotherCustom(); a11yAudit();`,
       errors: [
         { messageId: "a11yAuditAfterHelper" },
         { messageId: "a11yAuditAfterHelper" },
       ],
+    },
+    // using custom helper (default import)
+    {
+      code: `
+        import myCustom from 'custom';
+        myCustom();`,
+      settings: {
+        "ember-a11y-testing": {
+          modules: {
+            custom: {
+              include: ["default"],
+            },
+          },
+        },
+      },
+      output: `
+        import myCustom from 'custom';
+        myCustom(); a11yAudit();`,
+      errors: [{ messageId: "a11yAuditAfterHelper" }],
     },
 
     //

--- a/tests/lib/rules/a11y-audit-after-test-helper.js
+++ b/tests/lib/rules/a11y-audit-after-test-helper.js
@@ -16,7 +16,6 @@ const { RuleTester } = require("eslint/lib/rule-tester");
 // Tests
 //------------------------------------------------------------------------------
 
-const TEST_FILE_NAME = "tests/acceptance/application-test.js";
 const ruleTester = new RuleTester();
 
 function runWithModernSyntax(testName, rule, options) {
@@ -49,32 +48,17 @@ runWithModernSyntax("a11y-audit-after-test-helper", rule, {
       import { visit } from '@ember/test-helpers';
       visit();
       a11yAudit();`,
-      filename: TEST_FILE_NAME,
     },
     {
       code: `
       import { visit } from '@ember/test-helpers';
       visit();
       a11yAudit();`,
-      filename: TEST_FILE_NAME,
-    },
-
-    // rule not applicable outside of tests/acceptance folder
-    {
-      code: `import { visit } from '@ember/test-helpers'; visit();`,
-      filename: "app/controllers/application.js",
-    },
-
-    // rule not applicable in non-acceptance tests
-    {
-      code: `import { visit } from '@ember/test-helpers'; visit();`,
-      filename: "tests/integration/my-test.js",
     },
 
     // rule not applicable if function is excluded
     {
       code: `import { visit } from '@ember/test-helpers'; visit();`,
-      filename: TEST_FILE_NAME,
       settings: {
         "ember-a11y-testing": {
           modules: {
@@ -91,35 +75,27 @@ runWithModernSyntax("a11y-audit-after-test-helper", rule, {
     //
     {
       code: `import { blur } from '@ember/test-helpers'; blur(); a11yAudit();`,
-      filename: TEST_FILE_NAME,
     },
     {
       code: `import { click } from '@ember/test-helpers'; click(); a11yAudit();`,
-      filename: TEST_FILE_NAME,
     },
     {
       code: `import { doubleClick } from '@ember/test-helpers'; doubleClick(); a11yAudit();`,
-      filename: TEST_FILE_NAME,
     },
     {
       code: `import { focus } from '@ember/test-helpers'; focus(); a11yAudit();`,
-      filename: TEST_FILE_NAME,
     },
     {
       code: `import { tap } from '@ember/test-helpers'; tap(); a11yAudit();`,
-      filename: TEST_FILE_NAME,
     },
     {
       code: `import { triggerEvent } from '@ember/test-helpers'; triggerEvent(); a11yAudit();`,
-      filename: TEST_FILE_NAME,
     },
     {
       code: `import { triggerKeyEvent } from '@ember/test-helpers'; triggerKeyEvent(); a11yAudit();`,
-      filename: TEST_FILE_NAME,
     },
     {
       code: `import { triggerKeyEvent } from '@ember/test-helpers'; async function foo() { await triggerKeyEvent(); await a11yAudit(); }`,
-      filename: TEST_FILE_NAME,
     },
     // for of inside await
     {
@@ -131,7 +107,6 @@ runWithModernSyntax("a11y-audit-after-test-helper", rule, {
           await blur(); a11yAudit();
         }
       }`,
-      filename: TEST_FILE_NAME,
     },
   ],
   invalid: [
@@ -145,7 +120,6 @@ runWithModernSyntax("a11y-audit-after-test-helper", rule, {
           }
         }`,
       errors: [{ messageId: "a11yAuditAfterHelper" }],
-      filename: TEST_FILE_NAME,
       output: `import { blur, fillIn } from "@ember/test-helpers";
         async function doStuff() {
           for await (const x of y) {
@@ -164,7 +138,6 @@ runWithModernSyntax("a11y-audit-after-test-helper", rule, {
           }
         }`,
       errors: [{ messageId: "a11yAuditAfterHelper" }],
-      filename: TEST_FILE_NAME,
       output: `import { blur as blur2 /* woo hoo */, fillIn } from "@ember/test-helpers";
         async function doStuff() {
           for await (const x of y) {
@@ -177,7 +150,6 @@ runWithModernSyntax("a11y-audit-after-test-helper", rule, {
     {
       code: `import { fillIn } from "@ember/test-helpers"; assert.throws(fillIn('foo', 'bar'));`,
       errors: [{ messageId: "a11yAuditAfterHelper" }],
-      filename: TEST_FILE_NAME,
       output: `import { fillIn } from "@ember/test-helpers"; assert.throws(fillIn('foo', 'bar'));`,
     },
     // without adding a11yAudit after using `include` option
@@ -193,7 +165,6 @@ runWithModernSyntax("a11y-audit-after-test-helper", rule, {
         },
       },
       errors: [{ messageId: "a11yAuditAfterHelper" }],
-      filename: TEST_FILE_NAME,
       output: `import {myCustom} from "custom"; myCustom(); a11yAudit();`,
     },
     // without adding a11yAudit after using `include` option (multiple)
@@ -220,7 +191,6 @@ runWithModernSyntax("a11y-audit-after-test-helper", rule, {
 
         anotherCustom(); a11yAudit();`,
       errors: [{ messageId: "a11yAuditAfterHelper" }],
-      filename: TEST_FILE_NAME,
     },
     // using custom helper with ember test helpers
     {
@@ -253,7 +223,6 @@ runWithModernSyntax("a11y-audit-after-test-helper", rule, {
         { messageId: "a11yAuditAfterHelper" },
         { messageId: "a11yAuditAfterHelper" },
       ],
-      filename: TEST_FILE_NAME,
     },
 
     //
@@ -262,42 +231,36 @@ runWithModernSyntax("a11y-audit-after-test-helper", rule, {
     {
       code: 'import { blur } from "@ember/test-helpers"; blur();',
       errors: [{ messageId: "a11yAuditAfterHelper" }],
-      filename: TEST_FILE_NAME,
       output:
         'import { blur } from "@ember/test-helpers"; blur(); a11yAudit();',
     },
     {
       code: 'import { click } from "@ember/test-helpers"; click();',
       errors: [{ messageId: "a11yAuditAfterHelper" }],
-      filename: TEST_FILE_NAME,
       output:
         'import { click } from "@ember/test-helpers"; click(); a11yAudit();',
     },
     {
       code: 'import { doubleClick } from "@ember/test-helpers"; doubleClick();',
       errors: [{ messageId: "a11yAuditAfterHelper" }],
-      filename: TEST_FILE_NAME,
       output:
         'import { doubleClick } from "@ember/test-helpers"; doubleClick(); a11yAudit();',
     },
     {
       code: 'import { focus } from "@ember/test-helpers"; focus();',
       errors: [{ messageId: "a11yAuditAfterHelper" }],
-      filename: TEST_FILE_NAME,
       output:
         'import { focus } from "@ember/test-helpers"; focus(); a11yAudit();',
     },
     {
       code: 'import { tap } from "@ember/test-helpers"; tap();',
       errors: [{ messageId: "a11yAuditAfterHelper" }],
-      filename: TEST_FILE_NAME,
       output: 'import { tap } from "@ember/test-helpers"; tap(); a11yAudit();',
     },
     {
       code:
         'import { triggerEvent } from "@ember/test-helpers"; triggerEvent();',
       errors: [{ messageId: "a11yAuditAfterHelper" }],
-      filename: TEST_FILE_NAME,
       output:
         'import { triggerEvent } from "@ember/test-helpers"; triggerEvent(); a11yAudit();',
     },
@@ -305,7 +268,6 @@ runWithModernSyntax("a11y-audit-after-test-helper", rule, {
       code:
         'import { triggerKeyEvent } from "@ember/test-helpers"; triggerKeyEvent();',
       errors: [{ messageId: "a11yAuditAfterHelper" }],
-      filename: TEST_FILE_NAME,
       output:
         'import { triggerKeyEvent } from "@ember/test-helpers"; triggerKeyEvent(); a11yAudit();',
     },
@@ -317,7 +279,6 @@ runWithModernSyntax("a11y-audit-after-test-helper", rule, {
         await visit();
       }`,
       errors: [{ messageId: "a11yAuditAfterHelper" }],
-      filename: TEST_FILE_NAME,
       output: `
       import { visit } from '@ember/test-helpers';
       import a11yTesting24 from "ember-a11y-testing/test-support/audit";

--- a/tests/lib/rules/a11y-audit-no-expression.js
+++ b/tests/lib/rules/a11y-audit-no-expression.js
@@ -17,7 +17,6 @@ const { RuleTester } = require("eslint/lib/rule-tester");
 // Tests
 //------------------------------------------------------------------------------
 
-const TEST_FILE_NAME = "tests/acceptance/application-test.js";
 const ruleTester = new RuleTester();
 
 ruleTester.run("a11y-audit-no-expression", rule, {
@@ -25,12 +24,10 @@ ruleTester.run("a11y-audit-no-expression", rule, {
     // visit
     {
       code: `visit(); a11yAudit();`,
-      filename: TEST_FILE_NAME,
     },
     // import alias works
     {
       code: `import a11yAudit2 from 'ember-a11y-testing/ember-a11y-testing/test-support/audit'; (async () => { visit(); await a11yAudit2; })`,
-      filename: TEST_FILE_NAME,
       parserOptions: {
         ecmaVersion: "2018",
         sourceType: "module",
@@ -40,7 +37,6 @@ ruleTester.run("a11y-audit-no-expression", rule, {
     {
       code:
         'import { audit } from "dashboard/tests/helpers/audit"; (async () => { while(true) { visit(); await audit(); } })();',
-      filename: TEST_FILE_NAME,
       parserOptions: {
         ecmaVersion: "2018",
         sourceType: "module",
@@ -58,7 +54,6 @@ ruleTester.run("a11y-audit-no-expression", rule, {
     {
       code:
         'import audit from "dashboard/tests/helpers/audit"; (async () => { while(true) { visit(); await audit(); } })();',
-      filename: TEST_FILE_NAME,
       parserOptions: {
         ecmaVersion: "2018",
         sourceType: "module",
@@ -76,7 +71,6 @@ ruleTester.run("a11y-audit-no-expression", rule, {
     {
       code:
         'import audit from "dashboard/tests/helpers/audit"; const audit2 = audit; (async () => { while(true) { visit(); await audit2(); } })();',
-      filename: TEST_FILE_NAME,
       parserOptions: {
         ecmaVersion: "2018",
         sourceType: "module",
@@ -95,7 +89,6 @@ ruleTester.run("a11y-audit-no-expression", rule, {
     // import aliases work
     {
       code: `import a11yAudit24 from 'ember-a11y-testing/test-support/audit'; (async () => { visit(); await a11yAudit24; })()`,
-      filename: TEST_FILE_NAME,
       parserOptions: {
         ecmaVersion: "2018",
         sourceType: "module",
@@ -106,7 +99,6 @@ ruleTester.run("a11y-audit-no-expression", rule, {
     },
     {
       code: `import a11yAudit24 from 'ember-a11y-testing/test-support/audit'; (async () => { visit(); await a11yAudit24; })()`,
-      filename: TEST_FILE_NAME,
       parserOptions: {
         ecmaVersion: "2018",
         sourceType: "module",
@@ -119,7 +111,6 @@ ruleTester.run("a11y-audit-no-expression", rule, {
     {
       code: "visit(); a11yAudit;",
       errors: [{ messageId: "a11yAuditMustBeCalled" }],
-      filename: TEST_FILE_NAME,
       output: "visit(); a11yAudit();",
     },
     // async function
@@ -127,7 +118,6 @@ ruleTester.run("a11y-audit-no-expression", rule, {
       code: "(async function () { visit(); a11yAudit; })();",
       errors: [{ messageId: "a11yAuditMustBeCalled" }],
       output: "(async function () { visit(); await a11yAudit(); })();",
-      filename: TEST_FILE_NAME,
       parserOptions: {
         ecmaVersion: "2018",
       },
@@ -138,7 +128,6 @@ ruleTester.run("a11y-audit-no-expression", rule, {
       errors: [{ messageId: "a11yAuditMustBeCalled" }],
       output:
         "(async function () { while(true) { visit(); await a11yAudit(); } })();",
-      filename: TEST_FILE_NAME,
       parserOptions: {
         ecmaVersion: "2018",
       },
@@ -149,7 +138,6 @@ ruleTester.run("a11y-audit-no-expression", rule, {
       errors: [{ messageId: "a11yAuditMustBeCalled" }],
       output:
         "(async () => { while(true) { visit(); await a11yAudit(); } })();",
-      filename: TEST_FILE_NAME,
       parserOptions: {
         ecmaVersion: "2018",
       },
@@ -161,7 +149,6 @@ ruleTester.run("a11y-audit-no-expression", rule, {
       errors: [{ messageId: "a11yAuditMustBeCalled" }],
       output:
         'import { audit } from "dashboard/tests/helpers/audit"; (async () => { while(true) { visit(); await audit(); } })();',
-      filename: TEST_FILE_NAME,
       parserOptions: {
         ecmaVersion: "2018",
         sourceType: "module",
@@ -182,7 +169,6 @@ ruleTester.run("a11y-audit-no-expression", rule, {
       errors: [{ messageId: "a11yAuditMustBeCalled" }],
       output:
         'import audit from "dashboard/tests/helpers/audit"; (async () => { while(true) { visit(); await audit(); } })();',
-      filename: TEST_FILE_NAME,
       parserOptions: {
         ecmaVersion: "2018",
         sourceType: "module",

--- a/tests/lib/rules/a11y-audit-no-globals.js
+++ b/tests/lib/rules/a11y-audit-no-globals.js
@@ -17,14 +17,12 @@ const { RuleTester } = require("eslint/lib/rule-tester");
 // Tests
 //------------------------------------------------------------------------------
 
-const TEST_FILE_NAME = "tests/acceptance/application-test.js";
 const ruleTester = new RuleTester();
 
 ruleTester.run("a11y-audit-no-globals", rule, {
   valid: [
     {
       code: `import a11yAudit from 'ember-a11y-testing/test-support/audit'; a11yAudit();`,
-      filename: TEST_FILE_NAME,
       parserOptions: {
         ecmaVersion: "2018",
         sourceType: "module",
@@ -32,7 +30,6 @@ ruleTester.run("a11y-audit-no-globals", rule, {
     },
     {
       code: `import a11yAudit2 from 'ember-a11y-testing/test-support/audit'; a11yAudit2();`,
-      filename: TEST_FILE_NAME,
       parserOptions: {
         ecmaVersion: "2018",
         sourceType: "module",
@@ -40,7 +37,6 @@ ruleTester.run("a11y-audit-no-globals", rule, {
     },
     {
       code: `import a11yAudit2 from 'custom-module'; a11yAudit2();`,
-      filename: TEST_FILE_NAME,
       parserOptions: {
         ecmaVersion: "2018",
         sourceType: "module",
@@ -58,7 +54,6 @@ ruleTester.run("a11y-audit-no-globals", rule, {
   invalid: [
     {
       code: `a11yAudit();`,
-      filename: TEST_FILE_NAME,
       errors: [{ messageId: "a11yAuditNoGlobals" }],
       output: `import a11yAudit from 'ember-a11y-testing/test-support/audit';\na11yAudit();`,
       parserOptions: {
@@ -68,7 +63,6 @@ ruleTester.run("a11y-audit-no-globals", rule, {
     },
     {
       code: `/* existing import with comments */\nimport Blah from 'blah';\nimport Foo from 'foo'; a11yAudit();`,
-      filename: TEST_FILE_NAME,
       errors: [{ messageId: "a11yAuditNoGlobals" }],
       output: `/* existing import with comments */\nimport Blah from 'blah';\nimport Foo from 'foo';\nimport a11yAudit from 'ember-a11y-testing/test-support/audit';\n a11yAudit();`,
       parserOptions: {
@@ -78,7 +72,6 @@ ruleTester.run("a11y-audit-no-globals", rule, {
     },
     {
       code: `a11yAudit();`,
-      filename: TEST_FILE_NAME,
       errors: [{ messageId: "a11yAuditNoGlobals" }],
       output: `import { a11yAudit2 as a11yAudit } from 'custom-module';\na11yAudit();`,
       parserOptions: {
@@ -96,7 +89,6 @@ ruleTester.run("a11y-audit-no-globals", rule, {
     },
     {
       code: `import a11yAudit2 from 'ember-a11y-testing/test-support/audit'; a11yAudit();`,
-      filename: TEST_FILE_NAME,
       errors: [{ messageId: "a11yAuditNoGlobalsUseImportName" }],
       output: `import a11yAudit2 from 'ember-a11y-testing/test-support/audit'; a11yAudit2();`,
       parserOptions: {
@@ -106,7 +98,6 @@ ruleTester.run("a11y-audit-no-globals", rule, {
     },
     {
       code: `import a11yAudit2 from 'ember-a11y-testing/test-support/audit'; a11yAudit();`,
-      filename: TEST_FILE_NAME,
       errors: [{ messageId: "a11yAuditNoGlobalsUseImportName" }],
       output: `import a11yAudit2 from 'ember-a11y-testing/test-support/audit'; a11yAudit2();`,
       parserOptions: {
@@ -116,7 +107,6 @@ ruleTester.run("a11y-audit-no-globals", rule, {
     },
     {
       code: `import a11yAudit2 from 'custom-module'; a11yAudit();`,
-      filename: TEST_FILE_NAME,
       errors: [{ messageId: "a11yAuditNoGlobalsUseImportName" }],
       output: `import a11yAudit2 from 'custom-module'; a11yAudit2();`,
       parserOptions: {
@@ -134,7 +124,6 @@ ruleTester.run("a11y-audit-no-globals", rule, {
     },
     {
       code: `import { a11yAudit2 } from 'custom-module'; a11yAudit();`,
-      filename: TEST_FILE_NAME,
       errors: [{ messageId: "a11yAuditNoGlobalsUseImportName" }],
       output: `import { a11yAudit2 } from 'custom-module'; a11yAudit2();`,
       parserOptions: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -84,6 +84,11 @@ astral-regex@^1.0.0:
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-1.0.0.tgz#6c8c3fb827dd43ee3918f27b82782ab7658a6fd9"
   integrity sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==
 
+bail@^1.0.0:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/bail/-/bail-1.0.5.tgz#b6fa133404a392cbc1f8c4bf63f5953351e7a776"
+  integrity sha512-xFbRxM1tahm08yHBP16MMjVUAvDaBMD38zsM9EMAUN61omwLmKlOpB/Zku5QkjZ8TZ4vn53pj+t518cH0S03RQ==
+
 balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
@@ -120,6 +125,21 @@ chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.4.2:
     ansi-styles "^3.2.1"
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
+
+character-entities-legacy@^1.0.0:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/character-entities-legacy/-/character-entities-legacy-1.1.4.tgz#94bc1845dce70a5bb9d2ecc748725661293d8fc1"
+  integrity sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA==
+
+character-entities@^1.0.0:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/character-entities/-/character-entities-1.2.4.tgz#e12c3939b7eaf4e5b15e7ad4c5e28e1d48c5b16b"
+  integrity sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw==
+
+character-reference-invalid@^1.0.0:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/character-reference-invalid/-/character-reference-invalid-1.1.4.tgz#083329cda0eae272ab3dbbf37e9a382c13af1560"
+  integrity sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==
 
 chardet@^0.7.0:
   version "0.7.0"
@@ -159,6 +179,11 @@ cliui@^5.0.0:
     string-width "^3.1.0"
     strip-ansi "^5.2.0"
     wrap-ansi "^5.1.0"
+
+collapse-white-space@^1.0.2:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/collapse-white-space/-/collapse-white-space-1.0.6.tgz#e63629c0016665792060dbbeb79c42239d2c5287"
+  integrity sha512-jEovNnrhMuqyCcjfEJA56v0Xq8SkIoPKDyaHahwo3POf4qcSXqMYuwNcOTzp74vTsR9Tn08z4MxWqAhcekogkQ==
 
 color-convert@^1.9.0:
   version "1.9.3"
@@ -359,6 +384,15 @@ eslint-plugin-es@^3.0.0:
     eslint-utils "^2.0.0"
     regexpp "^3.0.0"
 
+eslint-plugin-markdown@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-markdown/-/eslint-plugin-markdown-1.0.2.tgz#79274bf17ce3ead48e4a55cbcb6d7ce735754280"
+  integrity sha512-BfvXKsO0K+zvdarNc801jsE/NTLmig4oKhZ1U3aSUgTf2dB/US5+CrfGxMsCK2Ki1vS1R3HPok+uYpufFndhzw==
+  dependencies:
+    object-assign "^4.0.1"
+    remark-parse "^5.0.0"
+    unified "^6.1.2"
+
 eslint-plugin-node@^11.1.0:
   version "11.1.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-node/-/eslint-plugin-node-11.1.0.tgz#c95544416ee4ada26740a30474eefc5402dc671d"
@@ -503,6 +537,11 @@ exit@0.1.2, exit@0.1.x:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/exit/-/exit-0.1.2.tgz#0632638f8d877cc82107d30a0fff1a17cba1cd0c"
   integrity sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=
+
+extend@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
+  integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
 
 external-editor@^3.0.3:
   version "3.1.0"
@@ -719,7 +758,7 @@ inherits@2:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
   integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
 
-inherits@~2.0.1:
+inherits@^2.0.0, inherits@~2.0.1:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -743,7 +782,20 @@ inquirer@^7.0.0:
     strip-ansi "^5.1.0"
     through "^2.3.6"
 
-is-buffer@~1.1.1:
+is-alphabetical@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-alphabetical/-/is-alphabetical-1.0.4.tgz#9e7d6b94916be22153745d184c298cbf986a686d"
+  integrity sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==
+
+is-alphanumerical@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-alphanumerical/-/is-alphanumerical-1.0.4.tgz#7eb9a2431f855f6b1ef1a78e326df515696c4dbf"
+  integrity sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A==
+  dependencies:
+    is-alphabetical "^1.0.0"
+    is-decimal "^1.0.0"
+
+is-buffer@^1.1.4, is-buffer@~1.1.1:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
@@ -762,6 +814,11 @@ is-date-object@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.2.tgz#bda736f2cd8fd06d32844e7743bfa7494c3bfd7e"
   integrity sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==
+
+is-decimal@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-decimal/-/is-decimal-1.0.4.tgz#65a3a5958a1c5b63a706e1b333d7cd9f630d3fa5"
+  integrity sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw==
 
 is-extglob@^2.1.1:
   version "2.1.1"
@@ -785,6 +842,16 @@ is-glob@^4.0.0, is-glob@^4.0.1:
   dependencies:
     is-extglob "^2.1.1"
 
+is-hexadecimal@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz#cc35c97588da4bd49a8eedd6bc4082d44dcb23a7"
+  integrity sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==
+
+is-plain-obj@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
+  integrity sha1-caUMhCnfync8kqOQpKA7OfzVHT4=
+
 is-promise@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.1.0.tgz#79a2a9ece7f096e80f36d2b2f3bc16c1ff4bf3fa"
@@ -803,6 +870,16 @@ is-symbol@^1.0.2:
   integrity sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==
   dependencies:
     has-symbols "^1.0.1"
+
+is-whitespace-character@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-whitespace-character/-/is-whitespace-character-1.0.4.tgz#0858edd94a95594c7c9dd0b5c174ec6e45ee4aa7"
+  integrity sha512-SDweEzfIZM0SJV0EUga669UTKlmL0Pq8Lno0QDQsPnvECB3IM2aP0gdx5TrU0A01MAPfViaZiI2V1QMZLaKK5w==
+
+is-word-character@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-word-character/-/is-word-character-1.0.4.tgz#ce0e73216f98599060592f62ff31354ddbeb0230"
+  integrity sha512-5SMO8RVennx3nZrqtKwCGyyetPE9VDba5ugvKLaD4KopPG5kR4mQ7tNt/r7feL5yt5h3lpuBbIUmCOG2eSzXHA==
 
 isarray@0.0.1:
   version "0.0.1"
@@ -878,6 +955,11 @@ log-symbols@2.2.0:
   integrity sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==
   dependencies:
     chalk "^2.0.1"
+
+markdown-escapes@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/markdown-escapes/-/markdown-escapes-1.0.4.tgz#c95415ef451499d7602b91095f3c8e8975f78535"
+  integrity sha512-8z4efJYk43E0upd0NbVXwgSTQs6cT3T06etieCMEg7dRbzCbxUCK/GHlX8mhHRDcp+OLlHkPKsvqQTCvsRl2cg==
 
 md5@^2.1.0:
   version "2.2.1"
@@ -1009,6 +1091,11 @@ node-environment-flags@1.0.5:
     object.getownpropertydescriptors "^2.0.3"
     semver "^5.7.0"
 
+object-assign@^4.0.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
+  integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
+
 object-inspect@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.7.0.tgz#f4f6bd181ad77f006b5ece60bd0b6f398ff74a67"
@@ -1094,6 +1181,18 @@ parent-module@^1.0.0:
   dependencies:
     callsites "^3.0.0"
 
+parse-entities@^1.1.0:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/parse-entities/-/parse-entities-1.2.2.tgz#c31bf0f653b6661354f8973559cb86dd1d5edf50"
+  integrity sha512-NzfpbxW/NPrzZ/yYSoQxyqUZMZXIdCfE0OIN4ESsnptHJECoUk3FZktxNuzQf4tjt5UEopnxpYJbvYuxIFDdsg==
+  dependencies:
+    character-entities "^1.0.0"
+    character-entities-legacy "^1.0.0"
+    character-reference-invalid "^1.0.0"
+    is-alphanumerical "^1.0.0"
+    is-decimal "^1.0.0"
+    is-hexadecimal "^1.0.0"
+
 path-exists@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-3.0.0.tgz#ce0ebeaa5f78cb18925ea7d810d7b59b010fd515"
@@ -1160,6 +1259,37 @@ regexpp@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.1.0.tgz#206d0ad0a5648cffbdb8ae46438f3dc51c9f78e2"
   integrity sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==
+
+remark-parse@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/remark-parse/-/remark-parse-5.0.0.tgz#4c077f9e499044d1d5c13f80d7a98cf7b9285d95"
+  integrity sha512-b3iXszZLH1TLoyUzrATcTQUZrwNl1rE70rVdSruJFlDaJ9z5aMkhrG43Pp68OgfHndL/ADz6V69Zow8cTQu+JA==
+  dependencies:
+    collapse-white-space "^1.0.2"
+    is-alphabetical "^1.0.0"
+    is-decimal "^1.0.0"
+    is-whitespace-character "^1.0.0"
+    is-word-character "^1.0.0"
+    markdown-escapes "^1.0.0"
+    parse-entities "^1.1.0"
+    repeat-string "^1.5.4"
+    state-toggle "^1.0.0"
+    trim "0.0.1"
+    trim-trailing-lines "^1.0.0"
+    unherit "^1.0.4"
+    unist-util-remove-position "^1.0.0"
+    vfile-location "^2.0.0"
+    xtend "^4.0.1"
+
+repeat-string@^1.5.4:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
+  integrity sha1-jcrkcOHIirwtYA//Sndihtp15jc=
+
+replace-ext@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/replace-ext/-/replace-ext-1.0.0.tgz#de63128373fcbf7c3ccfa4de5a480c45a67958eb"
+  integrity sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=
 
 require-directory@^2.1.1:
   version "2.1.1"
@@ -1272,6 +1402,11 @@ sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
+
+state-toggle@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/state-toggle/-/state-toggle-1.0.3.tgz#e123b16a88e143139b09c6852221bc9815917dfe"
+  integrity sha512-d/5Z4/2iiCnHw6Xzghyhb+GcmF89bxwgXG60wjIiZaxnymbyOmI8Hk4VqHXiVVp6u2ysaskFfXg3ekCj4WNftQ==
 
 "string-width@^1.0.2 || 2":
   version "2.1.1"
@@ -1415,6 +1550,21 @@ tmp@^0.0.33:
   dependencies:
     os-tmpdir "~1.0.2"
 
+trim-trailing-lines@^1.0.0:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/trim-trailing-lines/-/trim-trailing-lines-1.1.3.tgz#7f0739881ff76657b7776e10874128004b625a94"
+  integrity sha512-4ku0mmjXifQcTVfYDfR5lpgV7zVqPg6zV9rdZmwOPqq0+Zq19xDqEgagqVbc4pOOShbncuAOIs59R3+3gcF3ZA==
+
+trim@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/trim/-/trim-0.0.1.tgz#5858547f6b290757ee95cccc666fb50084c460dd"
+  integrity sha1-WFhUf2spB1fulczMZm+1AITEYN0=
+
+trough@^1.0.0:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/trough/-/trough-1.0.5.tgz#b8b639cefad7d0bb2abd37d433ff8293efa5f406"
+  integrity sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==
+
 tslib@^1.9.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
@@ -1432,6 +1582,57 @@ type-fest@^0.8.1:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
 
+unherit@^1.0.4:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/unherit/-/unherit-1.1.3.tgz#6c9b503f2b41b262330c80e91c8614abdaa69c22"
+  integrity sha512-Ft16BJcnapDKp0+J/rqFC3Rrk6Y/Ng4nzsC028k2jdDII/rdZ7Wd3pPT/6+vIIxRagwRc9K0IUX0Ra4fKvw+WQ==
+  dependencies:
+    inherits "^2.0.0"
+    xtend "^4.0.0"
+
+unified@^6.1.2:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/unified/-/unified-6.2.0.tgz#7fbd630f719126d67d40c644b7e3f617035f6dba"
+  integrity sha512-1k+KPhlVtqmG99RaTbAv/usu85fcSRu3wY8X+vnsEhIxNP5VbVIDiXnLqyKIG+UMdyTg0ZX9EI6k2AfjJkHPtA==
+  dependencies:
+    bail "^1.0.0"
+    extend "^3.0.0"
+    is-plain-obj "^1.1.0"
+    trough "^1.0.0"
+    vfile "^2.0.0"
+    x-is-string "^0.1.0"
+
+unist-util-is@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/unist-util-is/-/unist-util-is-3.0.0.tgz#d9e84381c2468e82629e4a5be9d7d05a2dd324cd"
+  integrity sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A==
+
+unist-util-remove-position@^1.0.0:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/unist-util-remove-position/-/unist-util-remove-position-1.1.4.tgz#ec037348b6102c897703eee6d0294ca4755a2020"
+  integrity sha512-tLqd653ArxJIPnKII6LMZwH+mb5q+n/GtXQZo6S6csPRs5zB0u79Yw8ouR3wTw8wxvdJFhpP6Y7jorWdCgLO0A==
+  dependencies:
+    unist-util-visit "^1.1.0"
+
+unist-util-stringify-position@^1.0.0, unist-util-stringify-position@^1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/unist-util-stringify-position/-/unist-util-stringify-position-1.1.2.tgz#3f37fcf351279dcbca7480ab5889bb8a832ee1c6"
+  integrity sha512-pNCVrk64LZv1kElr0N1wPiHEUoXNVFERp+mlTg/s9R5Lwg87f9bM/3sQB99w+N9D/qnM9ar3+AKDBwo/gm/iQQ==
+
+unist-util-visit-parents@^2.0.0:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz#25e43e55312166f3348cae6743588781d112c1e9"
+  integrity sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==
+  dependencies:
+    unist-util-is "^3.0.0"
+
+unist-util-visit@^1.1.0:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-1.4.1.tgz#4724aaa8486e6ee6e26d7ff3c8685960d560b1e3"
+  integrity sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==
+  dependencies:
+    unist-util-visit-parents "^2.0.0"
+
 uri-js@^4.2.2:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.2.2.tgz#94c540e1ff772956e2299507c010aea6c8838eb0"
@@ -1443,6 +1644,28 @@ v8-compile-cache@^2.0.3:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz#e14de37b31a6d194f5690d67efc4e7f6fc6ab30e"
   integrity sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g==
+
+vfile-location@^2.0.0:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/vfile-location/-/vfile-location-2.0.6.tgz#8a274f39411b8719ea5728802e10d9e0dff1519e"
+  integrity sha512-sSFdyCP3G6Ka0CEmN83A2YCMKIieHx0EDaj5IDP4g1pa5ZJ4FJDvpO0WODLxo4LUX4oe52gmSCK7Jw4SBghqxA==
+
+vfile-message@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/vfile-message/-/vfile-message-1.1.1.tgz#5833ae078a1dfa2d96e9647886cd32993ab313e1"
+  integrity sha512-1WmsopSGhWt5laNir+633LszXvZ+Z/lxveBf6yhGsqnQIhlhzooZae7zV6YVM1Sdkw68dtAW3ow0pOdPANugvA==
+  dependencies:
+    unist-util-stringify-position "^1.1.1"
+
+vfile@^2.0.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/vfile/-/vfile-2.3.0.tgz#e62d8e72b20e83c324bc6c67278ee272488bf84a"
+  integrity sha512-ASt4mBUHcTpMKD/l5Q+WJXNtshlWxOogYyGYYrg4lt/vuRjC1EFQtlAofL5VmtVNIZJzWYFJjzGWZ0Gw8pzW1w==
+  dependencies:
+    is-buffer "^1.1.4"
+    replace-ext "1.0.0"
+    unist-util-stringify-position "^1.0.0"
+    vfile-message "^1.0.0"
 
 which-module@^2.0.0:
   version "2.0.0"
@@ -1489,10 +1712,20 @@ write@1.0.3:
   dependencies:
     mkdirp "^0.5.1"
 
+x-is-string@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/x-is-string/-/x-is-string-0.1.0.tgz#474b50865af3a49a9c4657f05acd145458f77d82"
+  integrity sha1-R0tQhlrzpJqcRlfwWs0UVFj3fYI=
+
 xml@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/xml/-/xml-1.0.1.tgz#78ba72020029c5bc87b8a81a3cfcd74b4a2fc1e5"
   integrity sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=
+
+xtend@^4.0.0, xtend@^4.0.1:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
+  integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==
 
 y18n@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
Sometimes, one wants to define their own `render` or `click` or whatever function that is defined in `@ember/test-helpers` or their own module. This PR does a few things:

* Move config for `include/exclude` from config into `settings` for consistency
* Change format of `include/exclude` to allow for multiple modules beyond `@emberjs/test-helpers`.
* Looks at the `import` statements to determine what we need to pay attention to instead of only what's in `settings.modules`. This allows us to not conflict with the user's custom defined `visit`/similarly named functions. It also allows us to support import aliasing, e.g. `import { click as clickByAnyOtherName}`
* Lots of documentation
* Remove plugin's checking of running on acceptance tests. Users can opt out of this by using ESLint config overrides like they would with other plugins.
* Lints js code examples in our markdown files just to make sure my typos are copy/pastable. As a bonus the code examples are now prettier-ified as well.