### PR TITLE
Fix returning a helper

### DIFF
--- a/lib/rules/a11y-audit-after-test-helper.js
+++ b/lib/rules/a11y-audit-after-test-helper.js
@@ -96,10 +96,17 @@ module.exports = {
         }
 
         function visit(node) {
-          const parentExpressionStatementNode = utils.findParentOfType(
+          let parentExpressionStatementNode = utils.findParentOfType(
             node,
             "ExpressionStatement"
           );
+
+          if (!parentExpressionStatementNode) {
+            parentExpressionStatementNode = utils.findParentOfType(
+              node,
+              "ReturnStatement"
+            );
+          }
 
           const nextToken = context
             .getSourceCode()
@@ -164,11 +171,22 @@ module.exports = {
                   node,
                   /FunctionDeclaration/
                 );
+                let isInReturnStatement =
+                  parentFn &&
+                  parentExpressionStatementNode.type === "ReturnStatement";
                 let prefix = parentFn && parentFn.async ? "await " : "";
-                return fixer.insertTextAfter(
-                  node,
-                  `; ${prefix}${a11yAuditIdentifier}()`
-                );
+                if (isInReturnStatement) {
+                  // replace `return helper()` with `await helper(); return a11yAudit`
+                  const sourceCode = context.getSourceCode();
+                  const returnStatementArgumentCode = sourceCode.getText(node);
+                  let fixed = `${prefix}${returnStatementArgumentCode}; return ${a11yAuditIdentifier}();`;
+                  return fixer.replaceTextRange(
+                    parentExpressionStatementNode.range,
+                    fixed
+                  );
+                }
+                let fixed = `; ${prefix}${a11yAuditIdentifier}()`;
+                return fixer.insertTextAfter(node, fixed);
               },
             });
           }

--- a/lib/rules/a11y-audit-after-test-helper.js
+++ b/lib/rules/a11y-audit-after-test-helper.js
@@ -167,25 +167,33 @@ module.exports = {
                     }
                   }
                 }
-                let parentFn = utils.findParentOfType(
+                const parentFn = utils.findParentOfType(
                   node,
                   /FunctionDeclaration/
                 );
-                let isInReturnStatement =
+                const isInReturnStatement =
                   parentFn &&
                   parentExpressionStatementNode.type === "ReturnStatement";
-                let prefix = parentFn && parentFn.async ? "await " : "";
+                const prefix = parentFn && parentFn.async ? "await " : "";
+                const leftPadding =
+                  parentExpressionStatementNode.parent &&
+                  parentExpressionStatementNode.parent &&
+                  parentExpressionStatementNode.parent.type === "Program"
+                    ? // if we're in the top of the file, which we shouldn't be, just go to the next line
+                      // and let the user fix spacing issues with whatever eslint settings they have.
+                      "\n"
+                    : "\n" + "".padStart(node.parent.loc.start.column, " ");
                 if (isInReturnStatement) {
-                  // replace `return helper()` with `await helper(); return a11yAudit`
                   const sourceCode = context.getSourceCode();
+                  // replace `return helper()` with `await helper(); return a11yAudit`
                   const returnStatementArgumentCode = sourceCode.getText(node);
-                  let fixed = `${prefix}${returnStatementArgumentCode}; return ${a11yAuditIdentifier}();`;
+                  let fixed = `${prefix}${returnStatementArgumentCode};${leftPadding}return ${a11yAuditIdentifier}();`;
                   return fixer.replaceTextRange(
                     parentExpressionStatementNode.range,
                     fixed
                   );
                 }
-                let fixed = `; ${prefix}${a11yAuditIdentifier}()`;
+                let fixed = `;${leftPadding}${prefix}${a11yAuditIdentifier}()`;
                 return fixer.insertTextAfter(node, fixed);
               },
             });

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "requireindex": "~1.1.0"
   },
   "devDependencies": {
+    "common-tags": "^1.8.0",
     "eslint": "^6.8.0",
     "eslint-config-prettier": "^6.11.0",
     "eslint-plugin-markdown": "^1.0.2",

--- a/tests/lib/rules/a11y-audit-after-test-helper.js
+++ b/tests/lib/rules/a11y-audit-after-test-helper.js
@@ -110,6 +110,18 @@ runWithModernSyntax("a11y-audit-after-test-helper", rule, {
     },
   ],
   invalid: [
+    // returning a helper
+    {
+      code: `import { fillIn } from "@ember/test-helpers";
+            async function doStuff() {
+              return fillIn('#hi');
+            }`,
+      errors: [{ messageId: "a11yAuditAfterHelper" }],
+      output: `import { fillIn } from "@ember/test-helpers";
+            async function doStuff() {
+              await fillIn('#hi'); return a11yAudit();
+            }`,
+    },
     // nested block statements
     {
       code: `import { blur, fillIn } from "@ember/test-helpers";

--- a/tests/lib/rules/a11y-audit-after-test-helper.js
+++ b/tests/lib/rules/a11y-audit-after-test-helper.js
@@ -11,8 +11,8 @@
 
 const rule = require("../../../lib/rules/a11y-audit-after-test-helper");
 const { RuleTester } = require("eslint/lib/rule-tester");
+const { stripIndents: code } = require("common-tags");
 
-//------------------------------------------------------------------------------
 // Tests
 //------------------------------------------------------------------------------
 
@@ -44,13 +44,13 @@ runWithModernSyntax("a11y-audit-after-test-helper", rule, {
   valid: [
     // visit
     {
-      code: `
+      code: code`
       import { visit } from '@ember/test-helpers';
       visit();
       a11yAudit();`,
     },
     {
-      code: `
+      code: code`
       import { visit } from '@ember/test-helpers';
       visit();
       a11yAudit();`,
@@ -58,7 +58,7 @@ runWithModernSyntax("a11y-audit-after-test-helper", rule, {
 
     // rule not applicable if function is excluded
     {
-      code: `import { visit } from '@ember/test-helpers'; visit();`,
+      code: code`import { visit } from '@ember/test-helpers'; visit();`,
       settings: {
         "ember-a11y-testing": {
           modules: {
@@ -74,37 +74,39 @@ runWithModernSyntax("a11y-audit-after-test-helper", rule, {
     // smoke tests on other default test helpers
     //
     {
-      code: `import { blur } from '@ember/test-helpers'; blur(); a11yAudit();`,
+      code: code`import { blur } from '@ember/test-helpers'; blur();\na11yAudit();`,
     },
     {
-      code: `import { click } from '@ember/test-helpers'; click(); a11yAudit();`,
+      code: code`import { click } from '@ember/test-helpers'; click();\na11yAudit();`,
     },
     {
-      code: `import { doubleClick } from '@ember/test-helpers'; doubleClick(); a11yAudit();`,
+      code: code`import { doubleClick } from '@ember/test-helpers'; doubleClick();\na11yAudit();`,
     },
     {
-      code: `import { focus } from '@ember/test-helpers'; focus(); a11yAudit();`,
+      code: code`import { focus } from '@ember/test-helpers'; focus();\na11yAudit();`,
     },
     {
-      code: `import { tap } from '@ember/test-helpers'; tap(); a11yAudit();`,
+      code: code`import { tap } from '@ember/test-helpers'; tap();\na11yAudit();`,
     },
     {
-      code: `import { triggerEvent } from '@ember/test-helpers'; triggerEvent(); a11yAudit();`,
+      code: code`import { triggerEvent } from '@ember/test-helpers'; triggerEvent();\na11yAudit();`,
     },
     {
-      code: `import { triggerKeyEvent } from '@ember/test-helpers'; triggerKeyEvent(); a11yAudit();`,
+      code: code`import { triggerKeyEvent } from '@ember/test-helpers'; triggerKeyEvent();\na11yAudit();`,
     },
     {
-      code: `import { triggerKeyEvent } from '@ember/test-helpers'; async function foo() { await triggerKeyEvent(); await a11yAudit(); }`,
+      code: code`import { triggerKeyEvent } from '@ember/test-helpers'; async function foo() { await triggerKeyEvent();\nawait a11yAudit(); }`,
     },
     // for of inside await
     {
-      code: `
+      code: code`
       import { click, blur } from '@ember/test-helpers';
       async function doStuff() {
         for (const x of y) {
-          await click(); a11yAudit();
-          await blur(); a11yAudit();
+          await click();
+          a11yAudit();
+          await blur();
+          a11yAudit();
         }
       }`,
     },
@@ -112,57 +114,64 @@ runWithModernSyntax("a11y-audit-after-test-helper", rule, {
   invalid: [
     // returning a helper
     {
-      code: `import { fillIn } from "@ember/test-helpers";
+      code: code`import { fillIn } from "@ember/test-helpers";
             async function doStuff() {
               return fillIn('#hi');
             }`,
       errors: [{ messageId: "a11yAuditAfterHelper" }],
-      output: `import { fillIn } from "@ember/test-helpers";
+      output: code`import { fillIn } from "@ember/test-helpers";
             async function doStuff() {
-              await fillIn('#hi'); return a11yAudit();
+              await fillIn('#hi');
+              return a11yAudit();
             }`,
     },
     // nested block statements
     {
-      code: `import { blur, fillIn } from "@ember/test-helpers";
+      code: code`import { blur, fillIn } from "@ember/test-helpers";
         async function doStuff() {
           for await (const x of y) {
-            await fillIn(); await a11yAudit();
+            await fillIn();
+            await a11yAudit();
             await blur('[data-test-selector]');
           }
         }`,
       errors: [{ messageId: "a11yAuditAfterHelper" }],
-      output: `import { blur, fillIn } from "@ember/test-helpers";
+      output: code`import { blur, fillIn } from "@ember/test-helpers";
         async function doStuff() {
           for await (const x of y) {
-            await fillIn(); await a11yAudit();
-            await blur('[data-test-selector]'); await a11yAudit();
+            await fillIn();
+            await a11yAudit();
+            await blur('[data-test-selector]');
+            await a11yAudit();
           }
         }`,
     },
     // renaming ember test helper using import { helper as otherVariable }
     {
-      code: `import { blur as blur2 /* woo hoo */, fillIn } from "@ember/test-helpers";
+      code: code`import { blur as blur2 /* woo hoo */, fillIn } from "@ember/test-helpers";
         async function doStuff() {
           for await (const x of y) {
-            await fillIn(); await a11yAudit();
+            await fillIn();
+            await a11yAudit();
             await blur2('[data-test-selector]');
           }
         }`,
       errors: [{ messageId: "a11yAuditAfterHelper" }],
-      output: `import { blur as blur2 /* woo hoo */, fillIn } from "@ember/test-helpers";
+      output: code`import { blur as blur2 /* woo hoo */, fillIn } from "@ember/test-helpers";
         async function doStuff() {
           for await (const x of y) {
-            await fillIn(); await a11yAudit();
-            await blur2('[data-test-selector]'); await a11yAudit();
+            await fillIn();
+            await a11yAudit();
+            await blur2('[data-test-selector]');
+            await a11yAudit();
           }
         }`,
     },
     // doesn't try to autofix if passed to function
     {
-      code: `import { fillIn } from "@ember/test-helpers"; assert.throws(fillIn('foo', 'bar'));`,
+      code: code`import { fillIn } from "@ember/test-helpers"; assert.throws(fillIn('foo', 'bar'));`,
       errors: [{ messageId: "a11yAuditAfterHelper" }],
-      output: `import { fillIn } from "@ember/test-helpers"; assert.throws(fillIn('foo', 'bar'));`,
+      output: code`import { fillIn } from "@ember/test-helpers"; assert.throws(fillIn('foo', 'bar'));`,
     },
     // without adding a11yAudit after using `include` option
     {
@@ -177,11 +186,11 @@ runWithModernSyntax("a11y-audit-after-test-helper", rule, {
         },
       },
       errors: [{ messageId: "a11yAuditAfterHelper" }],
-      output: `import {myCustom} from "custom"; myCustom(); a11yAudit();`,
+      output: code`import {myCustom} from "custom"; myCustom();\na11yAudit();`,
     },
     // without adding a11yAudit after using `include` option (multiple)
     {
-      code: `
+      code: code`
         import { myCustom, anotherCustom } from 'custom';
         myCustom();
         a11yAudit();
@@ -196,17 +205,18 @@ runWithModernSyntax("a11y-audit-after-test-helper", rule, {
           },
         },
       },
-      output: `
+      output: code`
         import { myCustom, anotherCustom } from 'custom';
         myCustom();
         a11yAudit();
 
-        anotherCustom(); a11yAudit();`,
+        anotherCustom();
+        a11yAudit();`,
       errors: [{ messageId: "a11yAuditAfterHelper" }],
     },
     // using custom helper with ember test helpers
     {
-      code: `
+      code: code`
         import { myCustom, anotherCustom } from 'custom';
         import { click } from '@ember/test-helpers';
         myCustom();
@@ -223,14 +233,16 @@ runWithModernSyntax("a11y-audit-after-test-helper", rule, {
           },
         },
       },
-      output: `
+      output: code`
         import { myCustom, anotherCustom } from 'custom';
         import { click } from '@ember/test-helpers';
         myCustom();
         a11yAudit();
-        click(); a11yAudit();
+        click();
+        a11yAudit();
 
-        anotherCustom(); a11yAudit();`,
+        anotherCustom();
+        a11yAudit();`,
       errors: [
         { messageId: "a11yAuditAfterHelper" },
         { messageId: "a11yAuditAfterHelper" },
@@ -238,7 +250,7 @@ runWithModernSyntax("a11y-audit-after-test-helper", rule, {
     },
     // using custom helper (default import)
     {
-      code: `
+      code: code`
         import myCustom from 'custom';
         myCustom();`,
       settings: {
@@ -250,9 +262,10 @@ runWithModernSyntax("a11y-audit-after-test-helper", rule, {
           },
         },
       },
-      output: `
+      output: code`
         import myCustom from 'custom';
-        myCustom(); a11yAudit();`,
+        myCustom();
+        a11yAudit();`,
       errors: [{ messageId: "a11yAuditAfterHelper" }],
     },
 
@@ -263,58 +276,59 @@ runWithModernSyntax("a11y-audit-after-test-helper", rule, {
       code: 'import { blur } from "@ember/test-helpers"; blur();',
       errors: [{ messageId: "a11yAuditAfterHelper" }],
       output:
-        'import { blur } from "@ember/test-helpers"; blur(); a11yAudit();',
+        'import { blur } from "@ember/test-helpers"; blur();\na11yAudit();',
     },
     {
       code: 'import { click } from "@ember/test-helpers"; click();',
       errors: [{ messageId: "a11yAuditAfterHelper" }],
       output:
-        'import { click } from "@ember/test-helpers"; click(); a11yAudit();',
+        'import { click } from "@ember/test-helpers"; click();\na11yAudit();',
     },
     {
       code: 'import { doubleClick } from "@ember/test-helpers"; doubleClick();',
       errors: [{ messageId: "a11yAuditAfterHelper" }],
       output:
-        'import { doubleClick } from "@ember/test-helpers"; doubleClick(); a11yAudit();',
+        'import { doubleClick } from "@ember/test-helpers"; doubleClick();\na11yAudit();',
     },
     {
       code: 'import { focus } from "@ember/test-helpers"; focus();',
       errors: [{ messageId: "a11yAuditAfterHelper" }],
       output:
-        'import { focus } from "@ember/test-helpers"; focus(); a11yAudit();',
+        'import { focus } from "@ember/test-helpers"; focus();\na11yAudit();',
     },
     {
       code: 'import { tap } from "@ember/test-helpers"; tap();',
       errors: [{ messageId: "a11yAuditAfterHelper" }],
-      output: 'import { tap } from "@ember/test-helpers"; tap(); a11yAudit();',
+      output: 'import { tap } from "@ember/test-helpers"; tap();\na11yAudit();',
     },
     {
       code:
         'import { triggerEvent } from "@ember/test-helpers"; triggerEvent();',
       errors: [{ messageId: "a11yAuditAfterHelper" }],
       output:
-        'import { triggerEvent } from "@ember/test-helpers"; triggerEvent(); a11yAudit();',
+        'import { triggerEvent } from "@ember/test-helpers"; triggerEvent();\na11yAudit();',
     },
     {
       code:
         'import { triggerKeyEvent } from "@ember/test-helpers"; triggerKeyEvent();',
       errors: [{ messageId: "a11yAuditAfterHelper" }],
       output:
-        'import { triggerKeyEvent } from "@ember/test-helpers"; triggerKeyEvent(); a11yAudit();',
+        'import { triggerKeyEvent } from "@ember/test-helpers"; triggerKeyEvent();\na11yAudit();',
     },
     {
-      code: `
+      code: code`
       import { visit } from '@ember/test-helpers';
       import a11yTesting24 from "ember-a11y-testing/test-support/audit";
       async function foo() {
         await visit();
       }`,
       errors: [{ messageId: "a11yAuditAfterHelper" }],
-      output: `
+      output: code`
       import { visit } from '@ember/test-helpers';
       import a11yTesting24 from "ember-a11y-testing/test-support/audit";
       async function foo() {
-        await visit(); await a11yTesting24();
+        await visit();
+        await a11yTesting24();
       }`,
     },
   ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -197,6 +197,11 @@ color-name@1.1.3:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
 
+common-tags@^1.8.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/common-tags/-/common-tags-1.8.0.tgz#8e3153e542d4a39e9b10554434afaaf98956a937"
+  integrity sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw==
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"


### PR DESCRIPTION
fix returning a helper

turns:

```js
import { fillIn } from "@ember/test-helpers";
  async function doStuff() {
  return fillIn('#hi');
}
```

into:

```js
import { fillIn } from "@ember/test-helpers";
import a11yAudit from "ember-a11y-audit/test-support/audit";
async function doStuff() {
  await fillIn('#hi');
  return a11yAudit();
}
```
