### PR TITLE
Add rule for at least one call to a11y helper

### DIFF
--- a/lib/rules/a11y-audit-called.js
+++ b/lib/rules/a11y-audit-called.js
@@ -1,0 +1,79 @@
+"use strict";
+
+const utils = require("../utils");
+
+/**
+ * @fileoverview Enforce importing and calling a11yAudit at least once in a file.
+ * @author Buck Doyle <https://github.com/backspace>
+ */
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = {
+  meta: {
+    type: "problem",
+
+    description: "enforce a11yAudit must be called at least once",
+    category: "Accessibility",
+    recommended: true,
+    url:
+      "https://github.com/a11y-tool-sandbox/eslint-plugin-ember-a11y-testing/blob/master/lib/rules/a11y-audit-called.js",
+
+    schema: [],
+
+    messages: {
+      a11yAuditCalled: "`{{name}}` must be called",
+      a11yAuditImported: "a11y audit helper must be imported",
+    },
+  },
+
+  create(context) {
+    const settings = utils.extractSettings(context);
+
+    const a11yImportDeclaration = utils.findA11yAuditImportDeclaration(
+      context,
+      settings
+    );
+
+    if (a11yImportDeclaration) {
+      const a11yAuditIdentifier = a11yImportDeclaration.local.name;
+      let a11yAuditCalled = false;
+
+      return {
+        "Program:exit": function (node) {
+          if (!a11yAuditCalled) {
+            context.report({
+              node,
+              messageId: "a11yAuditCalled",
+              data: {
+                name: a11yAuditIdentifier,
+              },
+            });
+          }
+        },
+
+        CallExpression(node) {
+          let identifier = node.callee.type === "Identifier" && node.callee;
+          if (!identifier || identifier.name !== a11yAuditIdentifier) return;
+
+          a11yAuditCalled = true;
+        },
+      };
+    } else {
+      return {
+        Program: function (node) {
+          context.report({
+            node,
+            messageId: "a11yAuditImported",
+          });
+        },
+      };
+    }
+  },
+};

--- a/tests/lib/rules/a11y-audit-called.js
+++ b/tests/lib/rules/a11y-audit-called.js
@@ -1,0 +1,105 @@
+"use strict";
+
+/**
+ * @fileoverview Tests for a11y-audit-called rule.
+ * @author Buck Doyle <https://github.com/backspace>
+ */
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const rule = require("../../../lib/rules/a11y-audit-called");
+const { RuleTester } = require("eslint/lib/rule-tester");
+const { stripIndents: code } = require("common-tags");
+
+// Tests
+//------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester();
+
+function runWithModernSyntax(testName, rule, options) {
+  const makeTestModern = (testCase) => {
+    const defaultParserOptions = {
+      parserOptions: {
+        ecmaVersion: 2018,
+        sourceType: "module",
+      },
+    };
+    return {
+      ...defaultParserOptions,
+      ...testCase,
+    };
+  };
+  const validCases = (options.valid || []).map(makeTestModern);
+  const invalidCases = (options.invalid || []).map(makeTestModern);
+  return ruleTester.run(testName, rule, {
+    ...options,
+    valid: validCases,
+    invalid: invalidCases,
+  });
+}
+
+runWithModernSyntax("a11y-audit-called", rule, {
+  valid: [
+    {
+      code: code`import a11yAudit from 'ember-a11y-testing/test-support/audit';
+      a11yAudit();`,
+    },
+    {
+      code: code`import a11yAudit from 'ember-a11y-testing/test-support/audit';
+      import { visit } from '@ember/test-helpers';
+
+      function test1() {
+        visit();
+        a11yAudit();
+      }
+
+      function test2() {
+        visit();
+      }`,
+    },
+    {
+      code: `import a11yAudit2 from 'custom-module'; a11yAudit2();`,
+      parserOptions: {
+        ecmaVersion: "2018",
+        sourceType: "module",
+      },
+      settings: {
+        "ember-a11y-testing": {
+          auditModule: {
+            package: "custom-module",
+            exportName: "default",
+          },
+        },
+      },
+    },
+  ],
+  invalid: [
+    {
+      code: code`
+            import { fillIn } from "@ember/test-helpers";
+            import a11yAudit from 'ember-a11y-testing/test-support/audit';
+            async function doStuff() {
+              return fillIn('#hi');
+            }`,
+      errors: [{ messageId: "a11yAuditCalled" }],
+    },
+    {
+      code: `import audit from 'custom-module'; a11yAudit();`,
+      errors: [{ messageId: "a11yAuditCalled" }],
+      settings: {
+        "ember-a11y-testing": {
+          auditModule: {
+            package: "custom-module",
+            exportName: "default",
+          },
+        },
+      },
+    },
+    {
+      code: `a11yAudit();`,
+      errors: [{ messageId: "a11yAuditImported" }],
+    },
+  ],
+});


### PR DESCRIPTION
Hey all, thanks for the work on this, nice to see 😍

I was looking into making a custom ESLint rule as a followup to adding some [preliminary accessibility auditing](https://github.com/hashicorp/nomad/pull/8455) so we can ensure each acceptance test file includes at least one audit call and I found your relevant plugin. As it exists, it has some overlap with what I was looking for, but it differs in that we aren’t looking to audit after every page interaction (for now, at least), and `a11y-audit-after-test-helper` wouldn’t quite work anyway because we mostly use page objects in our acceptance tests, which have highly customisable helper names.

There’s an undocumented `a11y-audit` rule that looks like an attempt to do something closer to what we would need, but it doesn’t support the `settings` override that would let me specify the custom audit helper wrapper I added to let us centralise our rule overrides, which is imported from `nomad-ui/tests/helpers/a11y-audit` instead of the Ember addon. Also, forthcoming in my accessibility work is adding auditing for integration/component tests, which the existing `a11y-audit` rule wouldn’t apply to because of its [filename-checking](https://github.com/a11y-tool-sandbox/eslint-plugin-ember-a11y-testing/blob/master/lib/rules/a11y-audit.js#L17). If you like, I could open another PR to delete the `a11y-audit`, as it seems to have been superseded 🤔

So this is a prototype new rule that looks for the audit helper import (with name/package override options). I didn’t include autofix because it would have to arbitrarily pick somewhere in the file to make the call, it seems preferable to let the developer insert it where it makes sense. I’ve tested it successfully locally with `--rulesdir [local fork rules directory]` and this addition to `tests/.eslintrc.js`:

```
  overrides: {
    files: ['acceptance/**/*-test.js'],
    rules: {
      'a11y-audit-called': 'error',
    },
    'settings': {
      'ember-a11y-testing': {
        'auditModule': {
          'package': 'nomad-ui/tests/helpers/a11y-audit',
          'exportName': 'default'
        }
      }
    }
```

This isn’t necessarily a complete PR, it might be that some more test cases would be helpful, for instance, though I didn’t exercise all the import name/package overrides as that seemed well-covered elsewhere. Also, I didn’t love having the `a11yAuditImported` failure, which seemed to overlap too much with the `no-globals` rule, but I was near the end of my timebox for this attempt, but if you think it’s inappropriate, I can try to rework things so it’s not needed.

One uncertainty is that I put the organisation name as `a11y-tool-sandbox` in the rule file’s `url` field despite the others using `jgwhite`; I gather the package was moved from originally belonging to @jgwhite and I see that redirects are working, so for more consistency I could use that as well.

Let me know if you think this is something you’d be into including in your plugin and whether there are any changes you’d like to see to make that possible? It would be nice to have it live alongside the existing rules and share base utilities, but if you don’t think it belongs, I can also adapt the helpful utilities and have it instead as an in-repository plugin for Nomad.